### PR TITLE
Fix UUID-based payload download 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -228,9 +228,10 @@ func (a *Agent) DownloadPayloads(payloads []interface{}) []string {
 	availablePayloads := reflect.ValueOf(payloads)
 	for i := 0; i < availablePayloads.Len(); i++ {
 		payload := availablePayloads.Index(i).Elem().String()
-		location := filepath.Join(payload)
+		payloadBytes, filename := a.FetchPayloadBytes(payload)
+		location := filepath.Join(filename)
 		if !fileExists(location) {
-			if err := a.WritePayloadToDisk(payload, location); err != nil {
+			if err := a.WritePayloadToDisk(payloadBytes, location); err != nil {
 				output.VerbosePrint(fmt.Sprintf("[-] %s", err.Error()))
 				continue
 			}
@@ -242,8 +243,7 @@ func (a *Agent) DownloadPayloads(payloads []interface{}) []string {
 
 // Will download the specified payload and write it to disk at the specified location.
 // Assumes file does not already exist.
-func (a *Agent) WritePayloadToDisk(payload string, location string) error {
-	payloadBytes := a.FetchPayloadBytes(payload)
+func (a *Agent) WritePayloadToDisk(payloadBytes []byte, location string) error {
 	if len(payloadBytes) > 0 {
 		return writePayloadBytes(location, payloadBytes)
 	}
@@ -251,7 +251,7 @@ func (a *Agent) WritePayloadToDisk(payload string, location string) error {
 }
 
 // Will request payload bytes from the C2 for the specified payload and return them.
-func (a *Agent) FetchPayloadBytes(payload string) []byte {
+func (a *Agent) FetchPayloadBytes(payload string) ([]byte, string) {
 	output.VerbosePrint(fmt.Sprintf("[*] Fetching new payload bytes: %s", payload))
 	return a.beaconContact.GetPayloadBytes(a.GetTrimmedProfile(), payload)
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -246,13 +246,11 @@ func (a *Agent) WritePayloadToDisk(payload string) (string, error) {
 		location := filepath.Join(filename)
 		if !fileExists(location) {
 			return location, writePayloadBytes(location, payloadBytes)
-		} else {
-			output.VerbosePrint(fmt.Sprintf("[*] File %s already exists", filename))
-			return location, nil
 		}
-	} else {
-		return "", errors.New(fmt.Sprintf("Failed to fetch payload bytes for payload %s",payload))
+		output.VerbosePrint(fmt.Sprintf("[*] File %s already exists", filename))
+		return location, nil
 	}
+	return "", errors.New(fmt.Sprintf("Failed to fetch payload bytes for payload %s",payload))
 }
 
 // Will request payload bytes from the C2 for the specified payload and return them.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -168,8 +168,6 @@ func (a *Agent) Terminate() {
 func (a *Agent) RunInstruction(command map[string]interface{}, payloads []string) {
 	timeout := int(command["timeout"].(float64))
 	result := make(map[string]interface{})
-	// debug
-	output.VerbosePrint(fmt.Sprintf("command: %s, payloads %v", command["command"].(string), payloads))
 	commandOutput, status, pid := execute.RunCommand(command["command"].(string), payloads, command["executor"].(string), timeout)
 	result["id"] = command["id"]
 	result["output"] = commandOutput

--- a/contact/api.go
+++ b/contact/api.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 
 	"github.com/mitre/gocat/output"
 )
@@ -39,6 +40,7 @@ func (a API) GetBeaconBytes(profile map[string]interface{}) []byte {
 // Return the file bytes for the requested payload.
 func (a API) GetPayloadBytes(profile map[string]interface{}, payload string) []byte {
     var payloadBytes []byte
+    var filename string
     server := profile["server"]
     platform := profile["platform"]
     if server != nil && platform != nil {
@@ -55,6 +57,7 @@ func (a API) GetPayloadBytes(profile map[string]interface{}, payload string) []b
 				buf, err := ioutil.ReadAll(resp.Body)
 				if err == nil {
 					payloadBytes = buf
+					filename = filepath.Join(resp.Header["Filename"][0])
 				} else {
 					output.VerbosePrint(fmt.Sprintf("[-] Error reading HTTP response: %s", err.Error()))
 				}
@@ -62,7 +65,7 @@ func (a API) GetPayloadBytes(profile map[string]interface{}, payload string) []b
 		}
     }
 
-	return payloadBytes
+	return payloadBytes, filename
 }
 
 //C2RequirementsMet determines if sandcat can use the selected comm channel

--- a/contact/api.go
+++ b/contact/api.go
@@ -38,7 +38,7 @@ func (a API) GetBeaconBytes(profile map[string]interface{}) []byte {
 }
 
 // Return the file bytes for the requested payload.
-func (a API) GetPayloadBytes(profile map[string]interface{}, payload string) []byte {
+func (a API) GetPayloadBytes(profile map[string]interface{}, payload string) ([]byte, string) {
     var payloadBytes []byte
     var filename string
     server := profile["server"]

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -8,7 +8,7 @@ const (
 //Contact defines required functions for communicating with the server
 type Contact interface {
 	GetBeaconBytes(profile map[string]interface{}) []byte
-	GetPayloadBytes(profile map[string]interface{}, payload string) []byte
+	GetPayloadBytes(profile map[string]interface{}, payload string) ([]byte, string)
 	C2RequirementsMet(profile map[string]interface{}, criteria map[string]string) (bool, map[string]string)
 	SendExecutionResults(profile map[string]interface{}, result map[string]interface{})
 	GetName() string


### PR DESCRIPTION
- UUID payloads receive their filename from the actual download request; need to download the bytes and use the provided filename