### PR TITLE
VIRTS-762/VIRTS-896 Agent proxy information will now include the receiver addresses

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -244,6 +244,9 @@ func (a *Agent) Display() {
 				output.VerbosePrint(fmt.Sprintf("P2p receiver %s=NOT activated", receiverName))
 			}
 		}
+		for _, receiverInfo := range a.getProxyReceiverList() {
+			output.VerbosePrint(fmt.Sprintf("%s proxy receiver available at %s", receiverInfo[0], receiverInfo[1]))
+		}
 	}
 }
 

--- a/agent/agent_proxy.go
+++ b/agent/agent_proxy.go
@@ -30,3 +30,17 @@ func (a *Agent) TerminateP2pReceivers() {
 	}
 	a.p2pReceiverWaitGroup.Wait()
 }
+
+// Returns list of 2-tuple lists of form ["proxy protocol", "proxy receiver address"]
+func (a *Agent) getProxyReceiverList() [][]string {
+	var returnList [][]string
+	for receiverName, p2pReceiver := range a.validP2pReceivers {
+		for _, address := range p2pReceiver.GetReceiverAddresses() {
+			proxyInfo := make([]string, 2)
+			proxyInfo[0] = receiverName
+			proxyInfo[1] = address
+			returnList = append(returnList, proxyInfo)
+		}
+	}
+	return returnList
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -23,6 +23,7 @@ type P2pReceiver interface {
 	UpdateUpstreamServer(newServer string)
 	UpdateUpstreamComs(newComs contact.Contact)
 	Terminate()
+	GetReceiverAddresses() []string
 }
 
 // P2pClient will implement the contact.Contact interface.


### PR DESCRIPTION
In order for sandcat agents to tell the C2 server about its proxy receivers, it needs to know how other agents can reach its own listeners. The P2pReceiver interface now includes a method to get the receiver addresses, which the agent can then include. A future PR will take that information and place it in the profile for the server to process and include in the server-side agent data.

In tandem with https://github.com/mitre/sandcat/pull/314