### PR TITLE
Add proxy receiver field to agent profile to send to server

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -63,6 +63,7 @@ type Agent struct {
 	enableP2pReceivers bool
 	p2pReceiverWaitGroup *sync.WaitGroup
 	validP2pReceivers map[string]proxy.P2pReceiver
+	p2pReceiverAddresses [][]string
 }
 
 // Set up agent variables.
@@ -104,6 +105,7 @@ func (a *Agent) Initialize(server string, group string, c2Config map[string]stri
 	// Set up P2P receivers.
 	if a.enableP2pReceivers {
 		a.ActivateP2pReceivers()
+		a.p2pReceiverAddresses = a.getProxyReceiverList()
 	}
 	return nil
 }
@@ -124,6 +126,7 @@ func (a *Agent) GetFullProfile() map[string]interface{} {
 		"executors": a.executors,
 		"privilege": a.privilege,
 		"exe_name": a.exe_name,
+		"proxy_receivers": a.p2pReceiverAddresses,
 	}
 }
 
@@ -244,7 +247,7 @@ func (a *Agent) Display() {
 				output.VerbosePrint(fmt.Sprintf("P2p receiver %s=NOT activated", receiverName))
 			}
 		}
-		for _, receiverInfo := range a.getProxyReceiverList() {
+		for _, receiverInfo := range a.p2pReceiverAddresses {
 			output.VerbosePrint(fmt.Sprintf("%s proxy receiver available at %s", receiverInfo[0], receiverInfo[1]))
 		}
 	}


### PR DESCRIPTION
Agent will now send its proxy receiver information to the C2 server on a full beacon