### PR TITLE
Store proxy receiver addresses as dict

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -63,7 +63,7 @@ type Agent struct {
 	enableP2pReceivers bool
 	p2pReceiverWaitGroup *sync.WaitGroup
 	validP2pReceivers map[string]proxy.P2pReceiver
-	p2pReceiverAddresses [][]string
+	p2pReceiverAddresses map[string][]string // maps P2P protocol to list of receiver addresses.
 }
 
 // Set up agent variables.
@@ -105,7 +105,6 @@ func (a *Agent) Initialize(server string, group string, c2Config map[string]stri
 	// Set up P2P receivers.
 	if a.enableP2pReceivers {
 		a.ActivateP2pReceivers()
-		a.p2pReceiverAddresses = a.getProxyReceiverList()
 	}
 	return nil
 }
@@ -247,8 +246,10 @@ func (a *Agent) Display() {
 				output.VerbosePrint(fmt.Sprintf("P2p receiver %s=NOT activated", receiverName))
 			}
 		}
-		for _, receiverInfo := range a.p2pReceiverAddresses {
-			output.VerbosePrint(fmt.Sprintf("%s proxy receiver available at %s", receiverInfo[0], receiverInfo[1]))
+		for protocol, addressList := range a.p2pReceiverAddresses {
+			for _, address := range addressList {
+				output.VerbosePrint(fmt.Sprintf("%s proxy receiver available at %s", protocol, address))
+			}
 		}
 	}
 }

--- a/agent/agent_proxy.go
+++ b/agent/agent_proxy.go
@@ -19,12 +19,7 @@ func (a *Agent) ActivateP2pReceivers() {
 			output.VerbosePrint(fmt.Sprintf("[*] Initialized p2p receiver %s", receiverName))
 			a.validP2pReceivers[receiverName] = p2pReceiver
 			a.p2pReceiverWaitGroup.Add(1)
-			for _, address := range p2pReceiver.GetReceiverAddresses() {
-				if _, ok := a.p2pReceiverAddresses[receiverName]; !ok {
-					a.p2pReceiverAddresses[receiverName] = make([]string, 0)
-				}
-				a.p2pReceiverAddresses[receiverName] = append(a.p2pReceiverAddresses[receiverName], address)
-			}
+			a.storeP2pReceiverAddresses(receiverName, p2pReceiver)
 			go p2pReceiver.RunReceiver()
 		}
 	}
@@ -36,4 +31,13 @@ func (a *Agent) TerminateP2pReceivers() {
 		p2pReceiver.Terminate()
 	}
 	a.p2pReceiverWaitGroup.Wait()
+}
+
+func (a *Agent) storeP2pReceiverAddresses(receiverName string, p2pReceiver proxy.P2pReceiver) {
+	for _, address := range p2pReceiver.GetReceiverAddresses() {
+		if _, ok := a.p2pReceiverAddresses[receiverName]; !ok {
+			a.p2pReceiverAddresses[receiverName] = make([]string, 0)
+		}
+		a.p2pReceiverAddresses[receiverName] = append(a.p2pReceiverAddresses[receiverName], address)
+	}
 }

--- a/agent/agent_proxy.go
+++ b/agent/agent_proxy.go
@@ -10,6 +10,7 @@ import (
 
 func (a *Agent) ActivateP2pReceivers() {
 	a.validP2pReceivers = make(map[string]proxy.P2pReceiver)
+	a.p2pReceiverAddresses = make(map[string][]string)
 	a.p2pReceiverWaitGroup = &sync.WaitGroup{}
 	for receiverName, p2pReceiver := range proxy.P2pReceiverChannels {
 		if err := p2pReceiver.InitializeReceiver(a.server, a.beaconContact, a.p2pReceiverWaitGroup); err != nil {
@@ -18,6 +19,12 @@ func (a *Agent) ActivateP2pReceivers() {
 			output.VerbosePrint(fmt.Sprintf("[*] Initialized p2p receiver %s", receiverName))
 			a.validP2pReceivers[receiverName] = p2pReceiver
 			a.p2pReceiverWaitGroup.Add(1)
+			for _, address := range p2pReceiver.GetReceiverAddresses() {
+				if _, ok := a.p2pReceiverAddresses[receiverName]; !ok {
+					a.p2pReceiverAddresses[receiverName] = make([]string, 0)
+				}
+				a.p2pReceiverAddresses[receiverName] = append(a.p2pReceiverAddresses[receiverName], address)
+			}
 			go p2pReceiver.RunReceiver()
 		}
 	}
@@ -29,18 +36,4 @@ func (a *Agent) TerminateP2pReceivers() {
 		p2pReceiver.Terminate()
 	}
 	a.p2pReceiverWaitGroup.Wait()
-}
-
-// Returns list of 2-tuple lists of form ["proxy protocol", "proxy receiver address"]
-func (a *Agent) getProxyReceiverList() [][]string {
-	var returnList [][]string
-	for receiverName, p2pReceiver := range a.validP2pReceivers {
-		for _, address := range p2pReceiver.GetReceiverAddresses() {
-			proxyInfo := make([]string, 2)
-			proxyInfo[0] = receiverName
-			proxyInfo[1] = address
-			returnList = append(returnList, proxyInfo)
-		}
-	}
-	return returnList
 }


### PR DESCRIPTION
Instead of having the agent's proxy receiver addresses stored in a list of lists, store it in a dict with keys being the proxy protocol (e.g. HTTP, SmbPipe), and the value being the list of receiver addresses for each protocol. 