### PR TITLE
Agents can now obtain peer proxy information from server

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -64,6 +64,7 @@ type Agent struct {
 	p2pReceiverWaitGroup *sync.WaitGroup
 	validP2pReceivers map[string]proxy.P2pReceiver
 	p2pReceiverAddresses map[string][]string // maps P2P protocol to list of receiver addresses.
+	availablePeerReceivers map[string][]string
 }
 
 // Set up agent variables.
@@ -105,6 +106,11 @@ func (a *Agent) Initialize(server string, group string, c2Config map[string]stri
 	// Set up P2P receivers.
 	if a.enableP2pReceivers {
 		a.ActivateP2pReceivers()
+	}
+
+	a.availablePeerReceivers, err = proxy.GetAvailableReceivers()
+	if err != nil {
+		return err
 	}
 	return nil
 }
@@ -248,8 +254,13 @@ func (a *Agent) Display() {
 		}
 		for protocol, addressList := range a.p2pReceiverAddresses {
 			for _, address := range addressList {
-				output.VerbosePrint(fmt.Sprintf("%s proxy receiver available at %s", protocol, address))
+				output.VerbosePrint(fmt.Sprintf("%s local proxy receiver available at %s", protocol, address))
 			}
+		}
+	}
+	for protocol, addressList := range a.availablePeerReceivers {
+		for _, address := range addressList {
+			output.VerbosePrint(fmt.Sprintf("%s peer proxy receiver available at %s", protocol, address))
 		}
 	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -37,8 +37,17 @@ type P2pMessage struct {
 	populated bool
 }
 
-// P2pReceiverChannels contains the possible P2pReceiver implementations
-var P2pReceiverChannels = map[string]P2pReceiver{}
+var (
+	// P2pReceiverChannels contains the possible P2pReceiver implementations
+	P2pReceiverChannels = map[string]P2pReceiver{}
 
-// Contains the C2 Contact implementations strictly for peer-to-peer communications.
-var P2pClientChannels = map[string]contact.Contact{}
+	// Contains the C2 Contact implementations strictly for peer-to-peer communications.
+	P2pClientChannels = map[string]contact.Contact{}
+
+	// Contains the base64-encoded JSON-dumped list of available proxy receiver information
+	// in the form [["Proxy protocol 1","Proxy receiver 1"], ... ["Proxy protocol N","Proxy receiver N"]]
+	encodedReceivers = ""
+
+	// XOR key for the encoded proxy receiver info.
+	receiverKey = ""
+)


### PR DESCRIPTION
Server can dynamically compile peer proxy receiver addresses into the sandcat binary. The agent will decode the information to get the peer addresses for future use