### PR TITLE
Proxy fallback on failed beacon

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -20,6 +20,8 @@ import (
 	"github.com/mitre/gocat/proxy"
 )
 
+var beaconFailureThreshold = 3
+
 type AgentInterface interface {
 	Heartbeat()
 	Beacon() map[string]interface{}
@@ -34,6 +36,7 @@ type AgentInterface interface {
 	FetchPayloadBytes(payload string) []byte
 	ActivateLocalP2pReceivers()
 	TerminateLocalP2pReceivers()
+	HandleBeaconFailure() error
 }
 
 // Implements AgentInterface
@@ -57,6 +60,7 @@ type Agent struct {
 	// Communication methods
 	beaconContact contact.Contact
 	heartbeatContact contact.Contact
+	failedBeaconCounter int
 
 	// peer-to-peer info
 	enableLocalP2pReceivers bool
@@ -92,6 +96,7 @@ func (a *Agent) Initialize(server string, group string, c2Config map[string]stri
 	a.privilege = privdetect.Privlevel()
 	a.exe_name = filepath.Base(os.Args[0])
 	a.initialDelay = float64(initialDelay)
+	a.failedBeaconCounter = 0
 
 	// Paw will get initialized after successful beacon if it's not specified via command line
 	if paw != "" {
@@ -184,6 +189,19 @@ func processBeacon(data []byte) map[string]interface{} {
 	return beacon
 }
 
+// If too many consecutive failures occur for the current communication method, switch to a new proxy method.
+// Return an error if switch fails.
+func (a *Agent) HandleBeaconFailure() error {
+	a.failedBeaconCounter += 1
+	if a.failedBeaconCounter >= beaconFailureThreshold {
+		// Reset counter and try switching proxy methods
+		a.failedBeaconCounter = 0
+		output.VerbosePrint("[!] Reached beacon failure threshold. Attempting to switch to new peer proxy method.")
+		return a.findAvailablePeerProxyClient()
+	}
+	return nil
+}
+
 func (a *Agent) Heartbeat() {
 	// Add any heartbeat functionality here.
 }
@@ -269,6 +287,14 @@ func (a *Agent) displayLocalReceiverInformation() {
 		}
 	}
 	for protocol, addressList := range a.localP2pReceiverAddresses {
+		for _, address := range addressList {
+			output.VerbosePrint(fmt.Sprintf("%s local proxy receiver available at %s", protocol, address))
+		}
+	}
+}
+
+func (a *Agent) displayPeerReceiverInformation() {
+	for protocol, addressList := range a.availablePeerReceivers {
 		for _, address := range addressList {
 			output.VerbosePrint(fmt.Sprintf("%s local proxy receiver available at %s", protocol, address))
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -293,14 +293,6 @@ func (a *Agent) displayLocalReceiverInformation() {
 	}
 }
 
-func (a *Agent) displayPeerReceiverInformation() {
-	for protocol, addressList := range a.availablePeerReceivers {
-		for _, address := range addressList {
-			output.VerbosePrint(fmt.Sprintf("%s local proxy receiver available at %s", protocol, address))
-		}
-	}
-}
-
 // Will download each individual payload listed, write them to disk,
 // and will return the full file paths of each downloaded payload.
 func (a *Agent) DownloadPayloads(payloads []interface{}) []string {

--- a/core/core.go
+++ b/core/core.go
@@ -47,9 +47,6 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 		if len(beacon) != 0 {
 			sandcatAgent.SetPaw(beacon["paw"].(string))
 			checkin = time.Now()
-
-			// We have established comms. Run p2p receivers if allowed.
-			// TODO
 		}
 		if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
 			// Run commands and send results.
@@ -72,6 +69,11 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 				sleepDuration = float64(beacon["sleep"].(int))
 				watchdog = beacon["watchdog"].(int)
 			} else {
+				// Failed beacon
+				if err := sandcatAgent.HandleBeaconFailure(); err != nil {
+					output.VerbosePrint(fmt.Sprintf("[!] Error handling failed beacon: %s", err.Error()))
+					return
+				}
 				sleepDuration = float64(15)
 			}
 			sandcatAgent.Sleep(sleepDuration)


### PR DESCRIPTION
Agent will fall back to proxy receiver methods if its current C2 communication methods fail beacons 3 times in a row. If the agent is already using a peer-to-peer proxy receiver, it'll select a new one that it hasn't tried yet.