### PR TITLE
Making populated variable exported for json marshal

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -34,7 +34,7 @@ type P2pMessage struct {
 	SourceAddress string // return address for responses (e.g. IP + port, pipe path)
 	MessageType int
 	Payload []byte
-	populated bool
+	Populated bool
 }
 
 var (

--- a/proxy/proxy_util.go
+++ b/proxy/proxy_util.go
@@ -12,7 +12,7 @@ func buildP2pMsgBytes(sourcePaw string, messageType int, payload []byte, srcAddr
 		SourceAddress: srcAddr,
 		MessageType: messageType,
 		Payload: payload,
-		populated: true,
+		Populated: true,
 	}
 	return json.Marshal(p2pMsg)
 }
@@ -28,7 +28,7 @@ func bytesToP2pMsg(data []byte) (P2pMessage, error) {
 
 // Check if message is empty.
 func msgIsEmpty(msg P2pMessage) bool {
-	return !msg.populated
+	return !msg.Populated
 }
 
 func decodeXor(ciphertext string, xorKey string) string {


### PR DESCRIPTION
Fixing bug where p2p messages would be received, but determined to be empty. Json marshal requires struct fields to be visible in its scope