### PR TITLE
Adding http proxy gateway argument to sandcat binary

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,11 +1,9 @@
 package agent
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -75,7 +73,6 @@ type Agent struct {
 
 // Set up agent variables.
 func (a *Agent) Initialize(server string, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string) error {
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	host, err := os.Hostname()
 	if err != nil {
 		return err

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -9,7 +9,7 @@ const (
 type Contact interface {
 	GetBeaconBytes(profile map[string]interface{}) []byte
 	GetPayloadBytes(profile map[string]interface{}, payload string) ([]byte, string)
-	C2RequirementsMet(profile map[string]interface{}, criteria map[string]string) (bool, map[string]string)
+	C2RequirementsMet(profile map[string]interface{}, c2Config map[string]string) (bool, map[string]string)
 	SendExecutionResults(profile map[string]interface{}, result map[string]interface{})
 	GetName() string
 }

--- a/core/core.go
+++ b/core/core.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Initializes and returns sandcat agent.
-func initializeCore(server string, group string,c2 map[string]string, p2pReceiversOn bool, initialDelay int, verbose bool, paw string) (*agent.Agent, error) {
+func initializeCore(server string, group string, c2 map[string]string, p2pReceiversOn bool, initialDelay int, verbose bool, paw string) (*agent.Agent, error) {
 	output.SetVerbose(verbose)
 	output.VerbosePrint("Starting sandcat in verbose mode.")
 	return agent.AgentFactory(server, group, c2, p2pReceiversOn, initialDelay, paw)

--- a/sandcat.go
+++ b/sandcat.go
@@ -19,6 +19,7 @@ var (
 	c2Name    = "HTTP"
 	c2Key     = ""
 	listenP2P = "false" // need to set as string to allow ldflags -X build-time variable change on server-side.
+	httpProxyGateway = ""
 )
 
 func main() {
@@ -27,6 +28,7 @@ func main() {
 		parsedListenP2P = false
 	}
 	server := flag.String("server", server, "The FQDN of the server")
+	httpProxyUrl :=  flag.String("httpProxyGateway", httpProxyGateway, "URL for the HTTP proxy gateway. For environments that use proxies to reach the internet.")
 	paw := flag.String("paw", paw, "Optionally specify a PAW on intialization")
 	group := flag.String("group", group, "Attach a group to this agent")
 	c2 := flag.String("c2", c2Name, "C2 Channel for agent")
@@ -36,6 +38,6 @@ func main() {
 
 	flag.Parse()
 
-	c2Config := map[string]string{"c2Name": *c2, "c2Key": c2Key}
+	c2Config := map[string]string{"c2Name": *c2, "c2Key": c2Key, "httpProxyGateway": *httpProxyUrl}
 	core.Core(*server, *group, *delay, c2Config, *listenP2P, *verbose, *paw)
 }


### PR DESCRIPTION
Sandcat binary can now have an HTTP proxy gateway url specified via commandline argument `httpProxyGateway`. The HTTP contact will use this to reach the C2 in environments where a proxy is used to access the internet