### PR TITLE
delete payload after executing link

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -217,6 +217,12 @@ func (a *Agent) RunInstruction(command map[string]interface{}, payloads []string
 	timeout := int(command["timeout"].(float64))
 	result := make(map[string]interface{})
 	commandOutput, status, pid := execute.RunCommand(command["command"].(string), payloads, command["executor"].(string), timeout)
+	for _, payloadPath := range payloads {
+		err = os.Remove(payloadPath)
+		if err {
+			output.VerbosePrint("[!] Failed to delete payload: " + payloadPath)
+		}
+	}
 	result["id"] = command["id"]
 	result["output"] = commandOutput
 	result["status"] = status

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -218,8 +218,8 @@ func (a *Agent) RunInstruction(command map[string]interface{}, payloads []string
 	result := make(map[string]interface{})
 	commandOutput, status, pid := execute.RunCommand(command["command"].(string), payloads, command["executor"].(string), timeout)
 	for _, payloadPath := range payloads {
-		err = os.Remove(payloadPath)
-		if err {
+		err := os.Remove(payloadPath)
+		if err != nil {
 			output.VerbosePrint("[!] Failed to delete payload: " + payloadPath)
 		}
 	}


### PR DESCRIPTION
Changes: 

- removes payloads after executing link

I like the simplicity of this but there's some tradeoffs: 

- operation that with multiple links requiring the same payload will download, drop, and delete the payload multiple times
- If an ability assumes the presence of a payload w/o explicitly declaring it, it will fail. 

It might be nice to add an option to Abilities that allows turning payload deletion on/off to let people control this -- but I think we should wait until after the next release to mess with the ability schema. 