### PR TITLE
Terminate cleanup

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -228,7 +228,7 @@ func (a *Agent) cleanupExecutable() {
 		return
 	}
 	if platform == "darwin" || platform == "linux" {
-		cmd = exec.Command("bash", "-c", fmt.Sprintf("sleep 5 && /bin/rm %s", location))
+		cmd = exec.Command("bash", "-c", fmt.Sprintf("sleep 5 && /bin/rm -f %s", location))
 	} else if platform == "windows" {
 		cmd = exec.Command("cmd.exe", "/c", fmt.Sprintf("timeout /nobreak /t 5 >nul 2>nul & del /f %s", location))
 	}


### PR DESCRIPTION
Sandcat agent will now delete the associated executable when agents terminate. Supports windows, linux, and mac

For linux/mac, the agent will make sure there is no one else using the executable before deleting it
For windows, only the last agent using the executable will be able to delete it, since attempting to delete the executable while others are using it will throw a permissions error