### PR TITLE
Cleaner sys call to avoid errors when determining token privileges for SYSTEM user

### DIFF
--- a/privdetect/privilegedetect_windows.go
+++ b/privdetect/privilegedetect_windows.go
@@ -62,7 +62,7 @@ func IsElevated(token syscall.Token) bool {
 	var outLen uint32
 	err := syscall.GetTokenInformation(token, TokenElevation, (*byte)(unsafe.Pointer(&isElevated)), uint32(unsafe.Sizeof(isElevated)), &outLen)
 	if err != nil {
-		output.VerbosePrint(fmt.Sprintf("Error getting token info: %s", err.Error()))
+		output.VerbosePrint(fmt.Sprintf("Error getting process token info: %s", err.Error()))
 		return false
 	}
 	return outLen == uint32(unsafe.Sizeof(isElevated)) && isElevated != 0
@@ -72,11 +72,8 @@ func Privlevel() string{
     token, err := syscall.OpenCurrentProcessToken()
     if err != nil {
     	output.VerbosePrint(fmt.Sprintf("Error opening current process token: %s", err.Error()))
-    	return "User"
-    }
-    if IsElevated(token) ==true {
+    } else if IsElevated(token) {
     	return "Elevated"
-    } else {
-    	return "User"
     }
+    return "User"
 }

--- a/privdetect/privilegedetect_windows.go
+++ b/privdetect/privilegedetect_windows.go
@@ -43,20 +43,6 @@ const (
 	errnoERROR_IO_PENDING = 997
 )
 
-var (
-	errERROR_IO_PENDING error = syscall.Errno(errnoERROR_IO_PENDING)
-)
-
-func errnoErr(e syscall.Errno) error {
-	switch e {
-	case 0:
-		return nil
-	case errnoERROR_IO_PENDING:
-		return errERROR_IO_PENDING
-	}
-	return e
-}
-
 func IsElevated(token syscall.Token) bool {
 	var isElevated uint32
 	var outLen uint32


### PR DESCRIPTION
Using syscall.GetTokenInformation instead of calling GetTokenInformation via syscall.Syscall6