### PR TITLE
Executor Run() improvements

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -216,8 +216,8 @@ func (a *Agent) Terminate() {
 func (a *Agent) RunInstruction(instruction map[string]interface{}, payloads []string) {
 	result := make(map[string]interface{})
 	info := execute.InstructionInfo{
-	    Profile: a.GetTrimmedProfile(),
-	    Instruction: instruction,
+		Profile: a.GetTrimmedProfile(),
+		Instruction: instruction,
 	}
 	commandOutput, status, pid := execute.RunCommand(info, payloads)
 	for _, payloadPath := range payloads {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -213,17 +213,20 @@ func (a *Agent) Terminate() {
 }
 
 // Runs a single instruction and send results.
-func (a *Agent) RunInstruction(command map[string]interface{}, payloads []string) {
-	timeout := int(command["timeout"].(float64))
+func (a *Agent) RunInstruction(instruction map[string]interface{}, payloads []string) {
 	result := make(map[string]interface{})
-	commandOutput, status, pid := execute.RunCommand(command["command"].(string), payloads, command["executor"].(string), timeout)
+	info := execute.InstructionInfo{
+	    Profile: a.GetTrimmedProfile(),
+	    Instruction: instruction,
+	}
+	commandOutput, status, pid := execute.RunCommand(info, payloads)
 	for _, payloadPath := range payloads {
 		err := os.Remove(payloadPath)
 		if err != nil {
 			output.VerbosePrint("[!] Failed to delete payload: " + payloadPath)
 		}
 	}
-	result["id"] = command["id"]
+	result["id"] = instruction["id"]
 	result["output"] = commandOutput
 	result["status"] = status
 	result["pid"] = pid

--- a/core/core.go
+++ b/core/core.go
@@ -48,21 +48,21 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 			sandcatAgent.SetPaw(beacon["paw"].(string))
 			checkin = time.Now()
 		}
-		if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
-			// Run commands and send results.
-			cmds := reflect.ValueOf(beacon["instructions"])
-			for i := 0; i < cmds.Len(); i++ {
-				marshaledCommand := cmds.Index(i).Elem().String()
-				var command map[string]interface{}
-				if err := json.Unmarshal([]byte(marshaledCommand), &command); err != nil {
-					output.VerbosePrint(fmt.Sprintf("[-] Error unpacking command: %v", err.Error()))
-				} else {
-					output.VerbosePrint(fmt.Sprintf("[*] Running instruction %s", command["id"]))
-					droppedPayloads := sandcatAgent.DownloadPayloads(command["payloads"].([]interface{}))
-					go sandcatAgent.RunInstruction(command, droppedPayloads)
-					sandcatAgent.Sleep(command["sleep"].(float64))
-				}
-			}
+        if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
+            // Run commands and send results.
+            instructions := reflect.ValueOf(beacon["instructions"])
+            for i := 0; i < instructions.Len(); i++ {
+                marshaledInstruction := instructions.Index(i).Elem().String()
+                var instruction map[string]interface{}
+                if err := json.Unmarshal([]byte(marshaledInstruction), &instruction); err != nil {
+                    output.VerbosePrint(fmt.Sprintf("[-] Error unpacking command: %v", err.Error()))
+                } else {
+                    output.VerbosePrint(fmt.Sprintf("[*] Running instruction %s", instruction["id"]))
+                    droppedPayloads := sandcatAgent.DownloadPayloads(instruction["payloads"].([]interface{}))
+                    go sandcatAgent.RunInstruction(instruction, droppedPayloads)
+                    sandcatAgent.Sleep(instruction["sleep"].(float64))
+                }
+            }
 		} else {
 			var sleepDuration float64
 			if len(beacon) > 0 {

--- a/core/core.go
+++ b/core/core.go
@@ -48,21 +48,21 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 			sandcatAgent.SetPaw(beacon["paw"].(string))
 			checkin = time.Now()
 		}
-        if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
-            // Run commands and send results.
-            instructions := reflect.ValueOf(beacon["instructions"])
-            for i := 0; i < instructions.Len(); i++ {
-                marshaledInstruction := instructions.Index(i).Elem().String()
-                var instruction map[string]interface{}
-                if err := json.Unmarshal([]byte(marshaledInstruction), &instruction); err != nil {
-                    output.VerbosePrint(fmt.Sprintf("[-] Error unpacking command: %v", err.Error()))
-                } else {
-                    output.VerbosePrint(fmt.Sprintf("[*] Running instruction %s", instruction["id"]))
-                    droppedPayloads := sandcatAgent.DownloadPayloads(instruction["payloads"].([]interface{}))
-                    go sandcatAgent.RunInstruction(instruction, droppedPayloads)
-                    sandcatAgent.Sleep(instruction["sleep"].(float64))
-                }
-            }
+		if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
+			// Run commands and send results.
+			instructions := reflect.ValueOf(beacon["instructions"])
+			for i := 0; i < instructions.Len(); i++ {
+				marshaledInstruction := instructions.Index(i).Elem().String()
+				var instruction map[string]interface{}
+				if err := json.Unmarshal([]byte(marshaledInstruction), &instruction); err != nil {
+					output.VerbosePrint(fmt.Sprintf("[-] Error unpacking command: %v", err.Error()))
+				} else {
+					output.VerbosePrint(fmt.Sprintf("[*] Running instruction %s", instruction["id"]))
+					droppedPayloads := sandcatAgent.DownloadPayloads(instruction["payloads"].([]interface{}))
+					go sandcatAgent.RunInstruction(instruction, droppedPayloads)
+					sandcatAgent.Sleep(instruction["sleep"].(float64))
+				}
+			}
 		} else {
 			var sleepDuration float64
 			if len(beacon) > 0 {

--- a/execute/execute.go
+++ b/execute/execute.go
@@ -25,8 +25,8 @@ type Executor interface {
 }
 
 type InstructionInfo struct {
-    Profile map[string]interface{}
-    Instruction map[string]interface{}
+	Profile map[string]interface{}
+	Instruction map[string]interface{}
 }
 
 func AvailableExecutors() (values []string) {
@@ -41,8 +41,8 @@ var Executors = map[string]Executor{}
 //RunCommand runs the actual command
 func RunCommand(info InstructionInfo, payloads []string) ([]byte, string, string) {
 	encodedCommand := info.Instruction["command"].(string)
-    executor := info.Instruction["executor"].(string)
-    timeout := int(info.Instruction["timeout"].(float64))
+	executor := info.Instruction["executor"].(string)
+	timeout := int(info.Instruction["timeout"].(float64))
 	var status string
 	var result []byte
 	var pid string

--- a/execute/shells/powershell.go
+++ b/execute/shells/powershell.go
@@ -24,7 +24,7 @@ func init() {
 	}
 }
 
-func (p *Powershell) Run(command string, timeout int) ([]byte, string, string) {
+func (p *Powershell) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
 	return runShellExecutor(*exec.Command(p.path, append(p.execArgs, command)...), timeout)
 }
 

--- a/execute/shells/shell.go
+++ b/execute/shells/shell.go
@@ -20,7 +20,7 @@ func init() {
 	}
 }
 
-func (s *Sh) Run(command string, timeout int) ([]byte, string, string) {
+func (s *Sh) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
 	return runShellExecutor(*exec.Command(s.path, append(s.execArgs, command)...), timeout)
 }
 


### PR DESCRIPTION
Initial pass at adding more functionality for executors. Changes made to pass more information to the executor's `Run()` function, giving the executor greater control over things like payload download.

Created an InstructionInfo struct to hold the profile (paw, server, platform, host) and instruction (link...) information, which is passed to an executor `Run()` function. The struct cuts down on line size: `Run(command string, timeout int, info execute.InstructionInfo)` instead of `Run(profile map[string]interface{}, instruction map[string]interface{}, command string, timeout int)`.

Note: This will always cause Sandcat to throw the following error message if running verbose output: "[-] Failed to fetch payload bytes for payload ProcessDump.donut". It is not possible to override the `WritePayloadToDisk()` method in `agent.go` using a contact or executor. This could be solved by adding an additional return value from the contact's `GetPayloadBytes()`, but this would require each return to include this value. Open to suggestions.
