### PR TITLE
Adding deadman ability capabilities to sandcat

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -57,7 +57,7 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 				if err := json.Unmarshal([]byte(marshaledInstruction), &instruction); err != nil {
 					output.VerbosePrint(fmt.Sprintf("[-] Error unpacking command: %v", err.Error()))
 				} else {
-					// I instruction is deadman, save it for later. Otherwise, run the instruction.
+					// If instruction is deadman, save it for later. Otherwise, run the instruction.
 					if (instruction["deadman"].(bool)) {
 						output.VerbosePrint(fmt.Sprintf("[*] Received deadman instruction %s", instruction["id"]))
 						sandcatAgent.StoreDeadmanInstruction(instruction)


### PR DESCRIPTION
Requires https://github.com/mitre/caldera/pull/1973

Sandcat agent will notify the C2 server that it supports deadman abilities. Any received deadman abilities will be saved to run prior to clean agent termination. When running deadman abilities, the agent will not send output or execution results to the server.