### PR TITLE
Re-add cmd executor

### DIFF
--- a/execute/shells/cmd.go
+++ b/execute/shells/cmd.go
@@ -1,0 +1,37 @@
+// +build windows
+
+package shells
+
+import (
+	"github.com/mitre/gocat/execute"
+	"os/exec"
+)
+
+type Cmd struct {
+	shortName string
+	path string
+	execArgs []string
+}
+
+func init() {
+	shell := &Cmd{
+		shortName: "cmd",
+		path: "cmd.exe",
+		execArgs: []string{"/C"},
+	}
+	if shell.CheckIfAvailable() {
+		execute.Executors[shell.shortName] = shell
+	}
+}
+
+func (c *Cmd) Run(command string, timeout int) ([]byte, string, string) {
+	return runShellExecutor(*exec.Command(c.path, append(c.execArgs, command)...), timeout)
+}
+
+func (c *Cmd) String() string {
+	return c.shortName
+}
+
+func (c *Cmd) CheckIfAvailable() bool {
+	return checkExecutorInPath(c.path)
+}


### PR DESCRIPTION
Re-adding the cmd executor. This previously existed, but seems to have disappeared during the move to the gocat repo.

Addresses https://github.com/mitre/caldera/issues/1974