### PR TITLE
Adding c2 switching capability for sandcat

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -40,6 +40,7 @@ type AgentInterface interface {
 	TerminateLocalP2pReceivers()
 	HandleBeaconFailure() error
 	DiscoverPeers()
+	AttemptSelectComChannel(requestedChannelConfig map[string]string, requestedChannel string) error
 }
 
 // Implements AgentInterface
@@ -142,6 +143,7 @@ func (a *Agent) GetFullProfile() map[string]interface{} {
 		"server": a.server,
 		"group": a.group,
 		"host": a.host,
+		"contact": a.beaconContact.GetName(),
 		"username": a.username,
 		"architecture": a.architecture,
 		"platform": a.platform,
@@ -154,6 +156,7 @@ func (a *Agent) GetFullProfile() map[string]interface{} {
 		"proxy_receivers": a.localP2pReceiverAddresses,
 		"origin_link_id": a.originLinkID,
 		"deadman_enabled": true,
+		"available_contacts": contact.GetAvailableCommChannels(),
 	}
 }
 
@@ -164,6 +167,7 @@ func (a *Agent) GetTrimmedProfile() map[string]interface{} {
 		"server": a.server,
 		"platform": a.platform,
 		"host": a.host,
+		"contact": a.beaconContact.GetName(),
 	}
 }
 
@@ -259,7 +263,7 @@ func (a *Agent) RunInstruction(instruction map[string]interface{}, payloads []st
 func (a *Agent) SetCommunicationChannels(requestedChannelConfig map[string]string) error {
 	if len(contact.CommunicationChannels) > 0 {
 		if requestedChannel, ok := requestedChannelConfig["c2Name"]; ok {
-			if err := a.attemptSelectComChannel(requestedChannelConfig, requestedChannel); err == nil {
+			if err := a.AttemptSelectComChannel(requestedChannelConfig, requestedChannel); err == nil {
 				return nil
 			}
 		}
@@ -271,18 +275,18 @@ func (a *Agent) SetCommunicationChannels(requestedChannelConfig map[string]strin
 }
 
 // Attempts to set a given communication channel for the agent.
-func (a *Agent) attemptSelectComChannel(requestedChannelConfig map[string]string, requestedChannel string) error {
+func (a *Agent) AttemptSelectComChannel(requestedChannelConfig map[string]string, requestedChannel string) error {
 	coms, ok := contact.CommunicationChannels[requestedChannel]
 	output.VerbosePrint(fmt.Sprintf("[*] Attempting to set channel %s", requestedChannel))
 	if !ok {
 		return errors.New(fmt.Sprintf("%s channel not available", requestedChannel))
 	}
+	a.updateUpstreamComs(coms)
 	valid, config := coms.C2RequirementsMet(a.GetFullProfile(), requestedChannelConfig)
 	if valid {
 		if config != nil {
 			a.modifyAgentConfiguration(config)
 		}
-		a.updateUpstreamComs(coms)
 		output.VerbosePrint(fmt.Sprintf("[*] Set communication channel to %s", requestedChannel))
 		return nil
 	}
@@ -468,4 +472,3 @@ func (a *Agent) DiscoverPeers() {
 
     <-ctx.Done()
 }
-

--- a/agent/agent_proxy.go
+++ b/agent/agent_proxy.go
@@ -56,7 +56,7 @@ func (a *Agent) findAvailablePeerProxyClient() error {
 			output.VerbosePrint(fmt.Sprintf("[-] Verifying proxy channel %s", proxyChannel))
 
 			// Attempt to set the new coms channel.
-			if err := a.attemptSelectComChannel(nil, proxyChannel); err != nil {
+			if err := a.AttemptSelectComChannel(nil, proxyChannel); err != nil {
 				output.VerbosePrint(fmt.Sprintf("[!] Error attempting to use proxy channel %s: %s", proxyChannel, err.Error()))
 
 				// Remove the invalid proxy channel from the pool. Safe to remove during iteration.

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -16,3 +16,11 @@ type Contact interface {
 
 //CommunicationChannels contains the contact implementations
 var CommunicationChannels = map[string]Contact{}
+
+func GetAvailableCommChannels() []string {
+	channels := make([]string, 0, len(CommunicationChannels))
+	for k := range CommunicationChannels {
+		channels = append(channels, k)
+	}
+	return channels
+}

--- a/core/core.go
+++ b/core/core.go
@@ -55,6 +55,7 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 		if beacon["new_contact"] != nil {
 			newChannel := beacon["new_contact"].(string)
 			c2Config["c2Name"] = newChannel
+			output.VerbosePrint(fmt.Sprintf("Received request to switch from C2 channel %s to %s", sandcatAgent.GetCurrentContactName(), newChannel))
 			if err := sandcatAgent.AttemptSelectComChannel(c2Config, newChannel); err != nil {
 				output.VerbosePrint(fmt.Sprintf("[!] Error switching communication channels: %s", err.Error()))
 			}

--- a/core/core.go
+++ b/core/core.go
@@ -50,6 +50,17 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 			sandcatAgent.SetPaw(beacon["paw"].(string))
 			checkin = time.Now()
 		}
+
+		// Check if we need to change contacts
+		if beacon["new_contact"] != nil {
+			newChannel := beacon["new_contact"].(string)
+			c2Config["c2Name"] = newChannel
+			if err := sandcatAgent.AttemptSelectComChannel(c2Config, newChannel); err != nil {
+				output.VerbosePrint(fmt.Sprintf("[!] Error switching communication channels: %s", err.Error()))
+			}
+		}
+
+		// Handle instructions
 		if beacon["instructions"] != nil && len(beacon["instructions"].([]interface{})) > 0 {
 			// Run commands and send results.
 			instructions := reflect.ValueOf(beacon["instructions"])

--- a/execute/shells/cmd.go
+++ b/execute/shells/cmd.go
@@ -24,7 +24,7 @@ func init() {
 	}
 }
 
-func (c *Cmd) Run(command string, timeout int) ([]byte, string, string) {
+func (c *Cmd) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
 	return runShellExecutor(*exec.Command(c.path, append(c.execArgs, command)...), timeout)
 }
 


### PR DESCRIPTION
Requires https://github.com/mitre/caldera/pull/1991

If the C2 server sends a new C2 contact for the agent to use, the agent will switch to it. The agent will also send its current C2 channel and available C2 channels to the server when beaconing