### PR TITLE
File upload capabilities

### DIFF
--- a/contact/api.go
+++ b/contact/api.go
@@ -143,6 +143,7 @@ func (a *API) UploadFileBytes(profile map[string]interface{}, uploadName string,
 		"Content-Type": contentType,
 		"X-Request-Id": fmt.Sprintf("%s-%s", profile["host"].(string), profile["paw"].(string)),
 		"User-Agent": userAgent,
+		"X-Paw": profile["paw"].(string),
 	}
 	req, err := createUploadRequest(uploadUrl, &requestBody, headers)
 	if err != nil {

--- a/contact/api.go
+++ b/contact/api.go
@@ -12,7 +12,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
 	"path/filepath"
 
 	"github.com/mitre/gocat/output"
@@ -20,6 +19,7 @@ import (
 
 var (
 	apiBeacon = "/beacon"
+	userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36"
 )
 
 //API communicates through HTTP
@@ -124,37 +124,32 @@ func (a *API) GetName() string {
 	return a.name
 }
 
-func (a *API) UploadFile(profile map[string]interface{}, path string) error {
+func (a *API) UploadFileBytes(profile map[string]interface{}, uploadName string, data []byte) error {
 	c2address, ok := profile["server"].(string)
-	userAgent := "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36"
 	if !ok {
 		return errors.New("No server address provided in profile.")
 	}
 	uploadUrl := c2address + "/file/upload"
-	file, err := os.Open(path)
+
+	// Set up the form
+	requestBody := bytes.Buffer{}
+	contentType, err := createUploadForm(&requestBody, data, uploadName)
+	if err != nil {
+		return nil
+	}
+
+	// Set up the request
+	headers := map[string]string{
+		"Content-Type": contentType,
+		"X-Request-Id": fmt.Sprintf("%s-%s", profile["host"].(string), profile["paw"].(string)),
+		"User-Agent": userAgent,
+	}
+	req, err := createUploadRequest(uploadUrl, &requestBody, headers)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-	requestBody := &bytes.Buffer{}
-	writer := multipart.NewWriter(requestBody)
-	part, err := writer.CreateFormFile("file", filepath.Base(path))
-	if err != nil {
-		return err
-	}
-	if _, err = io.Copy(part, file); err != nil {
-		return err
-	}
-	if err = writer.Close(); err != nil {
-		return err
-	}
-	req, err := http.NewRequest("POST", uploadUrl, requestBody)
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("X-Request-Id", fmt.Sprintf("%s-%s", profile["host"].(string), profile["paw"].(string)))
-	req.Header.Set("User-Agent", userAgent)
+
+	// Perform request and process response
 	resp, err := a.client.Do(req)
 	if err != nil {
 		return err
@@ -166,6 +161,31 @@ func (a *API) UploadFile(profile map[string]interface{}, path string) error {
 		return errors.New(fmt.Sprintf("Non-successful HTTP response status code: %d", resp.StatusCode))
 	}
 	return nil
+}
+
+func createUploadForm(requestBody *bytes.Buffer, data []byte, uploadName string) (string, error) {
+	writer := multipart.NewWriter(requestBody)
+	defer writer.Close()
+	dataReader := bytes.NewReader(data)
+	formWriter, err := writer.CreateFormFile("file", uploadName)
+	if err != nil {
+		return "", err
+	}
+	if _, err = io.Copy(formWriter, dataReader); err != nil {
+		return "", err
+	}
+	return writer.FormDataContentType(), nil
+}
+
+func createUploadRequest(uploadUrl string, requestBody *bytes.Buffer, headers map[string]string) (*http.Request, error) {
+	req, err := http.NewRequest("POST", uploadUrl, requestBody)
+	if err != nil {
+		return nil, err
+	}
+	for header, val := range headers {
+		req.Header.Set(header, val)
+	}
+	return req, nil
 }
 
 func (a *API) request(address string, data []byte) []byte {

--- a/contact/api.go
+++ b/contact/api.go
@@ -144,6 +144,7 @@ func (a *API) UploadFileBytes(profile map[string]interface{}, uploadName string,
 		"X-Request-Id": fmt.Sprintf("%s-%s", profile["host"].(string), profile["paw"].(string)),
 		"User-Agent": userAgent,
 		"X-Paw": profile["paw"].(string),
+		"X-Host": profile["host"].(string),
 	}
 	req, err := createUploadRequest(uploadUrl, &requestBody, headers)
 	if err != nil {

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -12,7 +12,7 @@ type Contact interface {
 	C2RequirementsMet(profile map[string]interface{}, c2Config map[string]string) (bool, map[string]string)
 	SendExecutionResults(profile map[string]interface{}, result map[string]interface{})
 	GetName() string
-	UploadFile(profile map[string]interface{}, path string) error
+	UploadFileBytes(profile map[string]interface{}, uploadName string, data []byte) error
 }
 
 //CommunicationChannels contains the contact implementations

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -12,6 +12,7 @@ type Contact interface {
 	C2RequirementsMet(profile map[string]interface{}, c2Config map[string]string) (bool, map[string]string)
 	SendExecutionResults(profile map[string]interface{}, result map[string]interface{})
 	GetName() string
+	UploadFile(profile map[string]interface{}, path string) error
 }
 
 //CommunicationChannels contains the contact implementations

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -14,6 +14,8 @@ const (
 	RESPONSE_INSTRUCTIONS = 4
 	RESPONSE_PAYLOAD_BYTES = 5
 	ACK_EXECUTION_RESULTS = 6
+	SEND_FILE_UPLOAD_BYTES = 7
+	RESPONSE_FILE_UPLOAD = 8
 )
 
 // P2pReceiver defines required functions for relaying messages between peers and an upstream peer/c2.


### PR DESCRIPTION
Initial framework for having built-in file upload capabilities for the agent and its C2 contact channels. Just as instructions from the C2 provide payloads to download for an instruction, the C2 will also provide any file paths to upload after executing the ability. The PR updates the Contact interface so that all C2 Contact implementations will need to allow file uploads. The HTTP contact implementation has been updated accordingly.
The files can be specified using local or absolute filepaths.