### PR TITLE
quick change to trim trailing slashes in URL

### DIFF
--- a/sandcat.go
+++ b/sandcat.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"strconv"
+	"strings"
 
 	"github.com/mitre/gocat/core"
 )
@@ -28,6 +29,7 @@ func main() {
 		parsedListenP2P = false
 	}
 	server := flag.String("server", server, "The FQDN of the server")
+	trimmed_server := strings.TrimRight(*server, "/")
 	httpProxyUrl :=  flag.String("httpProxyGateway", httpProxyGateway, "URL for the HTTP proxy gateway. For environments that use proxies to reach the internet.")
 	paw := flag.String("paw", paw, "Optionally specify a PAW on intialization")
 	group := flag.String("group", group, "Attach a group to this agent")
@@ -40,5 +42,5 @@ func main() {
 	flag.Parse()
 
 	c2Config := map[string]string{"c2Name": *c2, "c2Key": c2Key, "httpProxyGateway": *httpProxyUrl}
-	core.Core(*server, *group, *delay, c2Config, *listenP2P, *verbose, *paw, *originLinkID)
+	core.Core(trimmed_server, *group, *delay, c2Config, *listenP2P, *verbose, *paw, *originLinkID)
 }

--- a/sandcat.go
+++ b/sandcat.go
@@ -28,8 +28,7 @@ func main() {
 	if err != nil {
 		parsedListenP2P = false
 	}
-	server := flag.String("server", server, "The FQDN of the server")
-	trimmed_server := strings.TrimRight(*server, "/")
+	server := strings.TrimRight(*flag.String("server", server, "The FQDN of the server"), "/")
 	httpProxyUrl :=  flag.String("httpProxyGateway", httpProxyGateway, "URL for the HTTP proxy gateway. For environments that use proxies to reach the internet.")
 	paw := flag.String("paw", paw, "Optionally specify a PAW on intialization")
 	group := flag.String("group", group, "Attach a group to this agent")
@@ -42,5 +41,5 @@ func main() {
 	flag.Parse()
 
 	c2Config := map[string]string{"c2Name": *c2, "c2Key": c2Key, "httpProxyGateway": *httpProxyUrl}
-	core.Core(trimmed_server, *group, *delay, c2Config, *listenP2P, *verbose, *paw, *originLinkID)
+	core.Core(server, *group, *delay, c2Config, *listenP2P, *verbose, *paw, *originLinkID)
 }


### PR DESCRIPTION
Trimming trailing slashes in the server url to prevent beaconing issues when one is provided.