### PR TITLE
Payload executor rework

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -403,6 +403,7 @@ func (a *Agent) DownloadPayloadsForInstruction(instruction map[string]interface{
 
 		// Ask executor what to do with the payload bytes (keep in memory or save to disk)
 		if executor.DownloadPayloadToMemory(payloadName) {
+			output.VerbosePrint(fmt.Sprintf("[*] Storing payload %s in memory", payloadName))
 			inMemoryPayloads[payloadName] = payloadBytes
 		} else {
 			if location, err := a.WritePayloadToDisk(payloadName, payloadBytes); err != nil {
@@ -421,6 +422,7 @@ func (a *Agent) DownloadPayloadsForInstruction(instruction map[string]interface{
 func (a *Agent) WritePayloadToDisk(filename string, payloadBytes []byte) (string, error) {
 	location := filepath.Join(filename)
 	if !fileExists(location) {
+		output.VerbosePrint(fmt.Sprintf("[*] Writing payload %s to disk at %s", filename, location))
 		return location, writePayloadBytes(location, payloadBytes)
 	}
 	output.VerbosePrint(fmt.Sprintf("[*] File %s already exists", filename))

--- a/core/core.go
+++ b/core/core.go
@@ -77,8 +77,7 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 						sandcatAgent.StoreDeadmanInstruction(instruction)
 					} else {
 						output.VerbosePrint(fmt.Sprintf("[*] Running instruction %s", instruction["id"]))
-						droppedPayloads, inMemoryPayloads := sandcatAgent.DownloadPayloadsForInstruction(instruction)
-						go sandcatAgent.RunInstruction(instruction, droppedPayloads, inMemoryPayloads, true)
+						go sandcatAgent.RunInstruction(instruction, true)
 						sandcatAgent.Sleep(instruction["sleep"].(float64))
 					}
 				}

--- a/core/core.go
+++ b/core/core.go
@@ -77,8 +77,8 @@ func runAgent (sandcatAgent *agent.Agent, c2Config map[string]string) {
 						sandcatAgent.StoreDeadmanInstruction(instruction)
 					} else {
 						output.VerbosePrint(fmt.Sprintf("[*] Running instruction %s", instruction["id"]))
-						droppedPayloads := sandcatAgent.DownloadPayloads(instruction["payloads"].([]interface{}))
-						go sandcatAgent.RunInstruction(instruction, droppedPayloads, true)
+						droppedPayloads, inMemoryPayloads := sandcatAgent.DownloadPayloadsForInstruction(instruction)
+						go sandcatAgent.RunInstruction(instruction, droppedPayloads, inMemoryPayloads, true)
 						sandcatAgent.Sleep(instruction["sleep"].(float64))
 					}
 				}

--- a/execute/shells/cmd.go
+++ b/execute/shells/cmd.go
@@ -35,3 +35,7 @@ func (c *Cmd) String() string {
 func (c *Cmd) CheckIfAvailable() bool {
 	return checkExecutorInPath(c.path)
 }
+
+func (c* Cmd) DownloadPayloadToMemory(payloadName string) bool {
+	return false
+}

--- a/execute/shells/powershell.go
+++ b/execute/shells/powershell.go
@@ -34,4 +34,8 @@ func (p *Powershell) String() string {
 
 func (p *Powershell) CheckIfAvailable() bool {
 	return checkExecutorInPath(p.path)
-} 
+}
+
+func (p* Powershell) DownloadPayloadToMemory(payloadName string) bool {
+	return false
+}

--- a/execute/shells/shell.go
+++ b/execute/shells/shell.go
@@ -31,3 +31,7 @@ func (s *Sh) String() string {
 func (s *Sh) CheckIfAvailable() bool {
 	return checkExecutorInPath(s.path)
 }
+
+func (s* Sh) DownloadPayloadToMemory(payloadName string) bool {
+	return false
+}


### PR DESCRIPTION
Executors can now decide whether or not a downloaded payload should be kept in memory or written to disk. For most executors, payloads will always be written to disk. The donut executor will request .donut payloads to be stored in memory.
Moved the payload download inside the RunInstruction function to include payload downloads in the go routine in core.go

The logic flow for downloading payloads for instructions is now the following:
- agent checks what payloads are required, as well as the executor to use
- for each payload, the executor returns a boolean that determines if the payload should stay in memory or get written to disk
- The agent downloads each payload and passes the payload information to the executor (filepaths for payloads written to disk, as well as payload bytes for payloads stored in memory)
- The executor uses the downloaded/in-memory payloads to run the command accordingly.