### PR TITLE
check for peer paw in beacon proxy chain to detect p2p loops

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -116,6 +116,7 @@ func (a *Agent) Initialize(server string, group string, c2Config map[string]stri
 	a.exhaustedPeerReceivers = make(map[string][]string)
 	a.usingPeerReceivers = false
 	a.availablePeerReceivers, err = proxy.GetAvailablePeerReceivers()
+	a.availablePeerReceivers[c2Config["c2Name"]] = append(a.availablePeerReceivers[c2Config["c2Name"]], server)
 	if err != nil {
 		return err
 	}

--- a/proxy/proxy_util.go
+++ b/proxy/proxy_util.go
@@ -73,3 +73,17 @@ func updatePeerChain(clientProfile map[string]interface{}, forwarderPaw string, 
 	proxyChain = append(proxyChain, nextHop)
 	clientProfile["proxy_chain"] = proxyChain
 }
+
+// check if a given address/paw is contained in the peer chain
+func isInPeerChain(clientProfile map[string]interface{}, searchPaw string) bool {
+    // Proxy chain is a list of length-3 lists ([forwarder paw, receiver address, peer protocol])
+	if _, ok := clientProfile["proxy_chain"]; ok {
+		proxyChain := clientProfile["proxy_chain"].([]interface{})
+		for _, peer := range proxyChain {
+		    if peer.([]interface{})[0].(string) == searchPaw {
+		        return true
+		    }
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Depends on a PR in sandcat:
https://github.com/mitre/sandcat/pull/346

Also included is a one-line addition to add the caldera server in as a peer so in case the server connection is intermittent the peer can reconnect after attempting to connect through other peers (current behavior is that once an agent falls over to p2p proxying all initial server contact is lost).