### PR TITLE
Update contact and proxy interfaces for agents.

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -68,6 +68,7 @@ type Agent struct {
 	// Communication methods
 	beaconContact contact.Contact
 	failedBeaconCounter int
+	upstreamDestAddr string // address of server/peer that agent uses to contact C2
 
 	// peer-to-peer info
 	enableLocalP2pReceivers bool
@@ -94,6 +95,7 @@ func (a *Agent) Initialize(server string, group string, c2Config map[string]stri
 		return err
 	}
 	a.server = server
+	a.upstreamDestAddr = server
 	a.group = group
 	a.host = host
 	a.architecture = runtime.GOARCH
@@ -151,7 +153,7 @@ func (a *Agent) GetFullProfile() map[string]interface{} {
 		"server": a.server,
 		"group": a.group,
 		"host": a.host,
-		"contact": a.beaconContact.GetName(),
+		"contact": a.GetCurrentContactName(),
 		"username": a.username,
 		"architecture": a.architecture,
 		"platform": a.platform,
@@ -176,7 +178,7 @@ func (a *Agent) GetTrimmedProfile() map[string]interface{} {
 		"server": a.server,
 		"platform": a.platform,
 		"host": a.host,
-		"contact": a.beaconContact.GetName(),
+		"contact": a.GetCurrentContactName(),
 	}
 }
 
@@ -338,12 +340,13 @@ func (a *Agent) AttemptSelectComChannel(requestedChannelConfig map[string]string
 	if !ok {
 		return errors.New(fmt.Sprintf("%s channel not available", requestedChannel))
 	}
-	a.updateUpstreamComs(coms)
+	coms.SetUpstreamDestAddr(&a.upstreamDestAddr)
 	valid, config := coms.C2RequirementsMet(a.GetFullProfile(), requestedChannelConfig)
 	if valid {
 		if config != nil {
 			a.modifyAgentConfiguration(config)
 		}
+		a.updateUpstreamComs(coms)
 		output.VerbosePrint(fmt.Sprintf("[*] Set communication channel to %s", requestedChannel))
 		return nil
 	}
@@ -354,10 +357,11 @@ func (a *Agent) AttemptSelectComChannel(requestedChannelConfig map[string]string
 func (a *Agent) Display() {
 	output.VerbosePrint(fmt.Sprintf("initial delay=%d", int(a.initialDelay)))
 	output.VerbosePrint(fmt.Sprintf("server=%s", a.server))
+	output.VerbosePrint(fmt.Sprintf("upstream dest addr=%s", a.upstreamDestAddr))
 	output.VerbosePrint(fmt.Sprintf("group=%s", a.group))
 	output.VerbosePrint(fmt.Sprintf("privilege=%s", a.privilege))
 	output.VerbosePrint(fmt.Sprintf("allow local p2p receivers=%v", a.enableLocalP2pReceivers))
-	output.VerbosePrint(fmt.Sprintf("beacon channel=%s", a.beaconContact.GetName()))
+	output.VerbosePrint(fmt.Sprintf("beacon channel=%s", a.GetCurrentContactName()))
 	if a.enableLocalP2pReceivers {
 		a.displayLocalReceiverInformation()
 	}
@@ -473,24 +477,17 @@ func (a *Agent) modifyAgentConfiguration(config map[string]string) {
 	if val, ok := config["paw"]; ok {
 		a.SetPaw(val)
 	}
+	if val, ok := config["upstreamDest"]; ok {
+		a.updateUpstreamDestAddr(val)
+	}
 }
 
-func (a *Agent) updateUpstreamServer(newServer string) {
-	a.server = newServer
-	if a.localP2pReceivers != nil {
-		for _, receiver := range a.localP2pReceivers {
-			receiver.UpdateUpstreamServer(newServer)
-		}
-	}
+func (a *Agent) updateUpstreamDestAddr(newDestAddr string) {
+	a.upstreamDestAddr = newDestAddr
 }
 
 func (a *Agent) updateUpstreamComs(newComs contact.Contact) {
 	a.beaconContact = newComs
-	if a.localP2pReceivers != nil {
-		for _, receiver := range a.localP2pReceivers {
-			receiver.UpdateUpstreamComs(newComs)
-		}
-	}
 }
 
 func (a *Agent) evaluateNewPeers(results <- chan *zeroconf.ServiceEntry) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -340,7 +340,7 @@ func (a *Agent) AttemptSelectComChannel(requestedChannelConfig map[string]string
 	if !ok {
 		return errors.New(fmt.Sprintf("%s channel not available", requestedChannel))
 	}
-	coms.SetUpstreamDestAddr(&a.upstreamDestAddr)
+	coms.SetUpstreamDestAddr(a.upstreamDestAddr)
 	valid, config := coms.C2RequirementsMet(a.GetFullProfile(), requestedChannelConfig)
 	if valid {
 		if config != nil {
@@ -484,6 +484,7 @@ func (a *Agent) modifyAgentConfiguration(config map[string]string) {
 
 func (a *Agent) updateUpstreamDestAddr(newDestAddr string) {
 	a.upstreamDestAddr = newDestAddr
+	a.beaconContact.SetUpstreamDestAddr(newDestAddr)
 }
 
 func (a *Agent) updateUpstreamComs(newComs contact.Contact) {

--- a/agent/agent_proxy.go
+++ b/agent/agent_proxy.go
@@ -10,7 +10,7 @@ import (
 
 func (a *Agent) ActivateLocalP2pReceivers() {
 	for receiverName, p2pReceiver := range proxy.P2pReceiverChannels {
-		if err := p2pReceiver.InitializeReceiver(a.server, a.beaconContact, a.p2pReceiverWaitGroup); err != nil {
+		if err := p2pReceiver.InitializeReceiver(&a.server, &a.beaconContact, a.p2pReceiverWaitGroup); err != nil {
 			output.VerbosePrint(fmt.Sprintf("[-] Error when initializing p2p receiver %s: %s", receiverName, err.Error()))
 		} else {
 			output.VerbosePrint(fmt.Sprintf("[*] Initialized p2p receiver %s", receiverName))
@@ -63,11 +63,11 @@ func (a *Agent) findAvailablePeerProxyClient() error {
 				delete(a.availablePeerReceivers, proxyChannel)
 				continue
 			}
-			// Successfully set the channel. Update server.
+			// Successfully set the channel. Update dest address.
 			a.usingPeerReceivers = true
 			addressToUse := receiverAddresses[0]
-			a.updateUpstreamServer(addressToUse)
-			output.VerbosePrint(fmt.Sprintf("[*] Updated agent's server to proxy peer address: %s", addressToUse))
+			a.updateUpstreamDestAddr(addressToUse)
+			output.VerbosePrint(fmt.Sprintf("[*] Updated agent's destination address to proxy peer address: %s", addressToUse))
 
 			// Mark proxy channel and peer receiver address as used.
 			a.markPeerReceiverAsUsed(proxyChannel, addressToUse)

--- a/contact/api.go
+++ b/contact/api.go
@@ -26,7 +26,7 @@ var (
 type API struct {
 	name string
 	client *http.Client
-	upstreamDestAddr *string // pointer to agent's upstream dest addr
+	upstreamDestAddr string
 }
 
 func init() {
@@ -40,7 +40,7 @@ func (a *API) GetBeaconBytes(profile map[string]interface{}) []byte {
 		output.VerbosePrint(fmt.Sprintf("[-] Cannot request beacon. Error with profile marshal: %s", err.Error()))
 		return nil
 	} else {
-		address := fmt.Sprintf("%s%s", *a.upstreamDestAddr, apiBeacon)
+		address := fmt.Sprintf("%s%s", a.upstreamDestAddr, apiBeacon)
 		return a.request(address, data)
 	}
 }
@@ -51,7 +51,7 @@ func (a *API) GetPayloadBytes(profile map[string]interface{}, payload string) ([
     var filename string
     platform := profile["platform"]
     if platform != nil {
-		address := fmt.Sprintf("%s/file/download", *a.upstreamDestAddr)
+		address := fmt.Sprintf("%s/file/download", a.upstreamDestAddr)
 		req, err := http.NewRequest("POST", address, nil)
 		if err != nil {
 			output.VerbosePrint(fmt.Sprintf("[-] Failed to create HTTP request: %s", err.Error()))
@@ -102,13 +102,13 @@ func (a *API) C2RequirementsMet(profile map[string]interface{}, c2Config map[str
 	return true, nil
 }
 
-func (a *API) SetUpstreamDestAddr(upstreamDestAddr *string) {
+func (a *API) SetUpstreamDestAddr(upstreamDestAddr string) {
 	a.upstreamDestAddr = upstreamDestAddr
 }
 
 // SendExecutionResults will send the execution results to the upstream destination.
 func (a *API) SendExecutionResults(profile map[string]interface{}, result map[string]interface{}) {
-	address := fmt.Sprintf("%s%s", *a.upstreamDestAddr, apiBeacon)
+	address := fmt.Sprintf("%s%s", a.upstreamDestAddr, apiBeacon)
 	profileCopy := make(map[string]interface{})
 	for k,v := range profile {
 		profileCopy[k] = v
@@ -129,7 +129,7 @@ func (a *API) GetName() string {
 }
 
 func (a *API) UploadFileBytes(profile map[string]interface{}, uploadName string, data []byte) error {
-	uploadUrl := *a.upstreamDestAddr + "/file/upload"
+	uploadUrl := a.upstreamDestAddr + "/file/upload"
 
 	// Set up the form
 	requestBody := bytes.Buffer{}

--- a/contact/api.go
+++ b/contact/api.go
@@ -26,6 +26,7 @@ var (
 type API struct {
 	name string
 	client *http.Client
+	upstreamDestAddr *string // pointer to agent's upstream dest addr
 }
 
 func init() {
@@ -39,7 +40,7 @@ func (a *API) GetBeaconBytes(profile map[string]interface{}) []byte {
 		output.VerbosePrint(fmt.Sprintf("[-] Cannot request beacon. Error with profile marshal: %s", err.Error()))
 		return nil
 	} else {
-		address := fmt.Sprintf("%s%s", profile["server"], apiBeacon)
+		address := fmt.Sprintf("%s%s", *a.upstreamDestAddr, apiBeacon)
 		return a.request(address, data)
 	}
 }
@@ -48,10 +49,9 @@ func (a *API) GetBeaconBytes(profile map[string]interface{}) []byte {
 func (a *API) GetPayloadBytes(profile map[string]interface{}, payload string) ([]byte, string) {
     var payloadBytes []byte
     var filename string
-    server := profile["server"]
     platform := profile["platform"]
-    if server != nil && platform != nil {
-		address := fmt.Sprintf("%s/file/download", server.(string))
+    if platform != nil {
+		address := fmt.Sprintf("%s/file/download", *a.upstreamDestAddr)
 		req, err := http.NewRequest("POST", address, nil)
 		if err != nil {
 			output.VerbosePrint(fmt.Sprintf("[-] Failed to create HTTP request: %s", err.Error()))
@@ -102,9 +102,13 @@ func (a *API) C2RequirementsMet(profile map[string]interface{}, c2Config map[str
 	return true, nil
 }
 
-//SendExecutionResults will send the execution results to the server.
+func (a *API) SetUpstreamDestAddr(upstreamDestAddr *string) {
+	a.upstreamDestAddr = upstreamDestAddr
+}
+
+// SendExecutionResults will send the execution results to the upstream destination.
 func (a *API) SendExecutionResults(profile map[string]interface{}, result map[string]interface{}) {
-	address := fmt.Sprintf("%s%s", profile["server"], apiBeacon)
+	address := fmt.Sprintf("%s%s", *a.upstreamDestAddr, apiBeacon)
 	profileCopy := make(map[string]interface{})
 	for k,v := range profile {
 		profileCopy[k] = v
@@ -125,11 +129,7 @@ func (a *API) GetName() string {
 }
 
 func (a *API) UploadFileBytes(profile map[string]interface{}, uploadName string, data []byte) error {
-	c2address, ok := profile["server"].(string)
-	if !ok {
-		return errors.New("No server address provided in profile.")
-	}
-	uploadUrl := c2address + "/file/upload"
+	uploadUrl := *a.upstreamDestAddr + "/file/upload"
 
 	// Set up the form
 	requestBody := bytes.Buffer{}

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -12,6 +12,7 @@ type Contact interface {
 	C2RequirementsMet(profile map[string]interface{}, c2Config map[string]string) (bool, map[string]string)
 	SendExecutionResults(profile map[string]interface{}, result map[string]interface{})
 	GetName() string
+	SetUpstreamDestAddr(upstreamDestAddr *string)
 	UploadFileBytes(profile map[string]interface{}, uploadName string, data []byte) error
 }
 

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -12,7 +12,7 @@ type Contact interface {
 	C2RequirementsMet(profile map[string]interface{}, c2Config map[string]string) (bool, map[string]string)
 	SendExecutionResults(profile map[string]interface{}, result map[string]interface{})
 	GetName() string
-	SetUpstreamDestAddr(upstreamDestAddr *string)
+	SetUpstreamDestAddr(upstreamDestAddr string)
 	UploadFileBytes(profile map[string]interface{}, uploadName string, data []byte) error
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -20,10 +20,8 @@ const (
 
 // P2pReceiver defines required functions for relaying messages between peers and an upstream peer/c2.
 type P2pReceiver interface {
-	InitializeReceiver(server string, upstreamComs contact.Contact, waitgroup *sync.WaitGroup) error
+	InitializeReceiver(agentServer *string, upstreamComs *contact.Contact, waitgroup *sync.WaitGroup) error
 	RunReceiver() // must be run as a go routine
-	UpdateUpstreamServer(newServer string)
-	UpdateUpstreamComs(newComs contact.Contact)
 	UpdateAgentPaw(newPaw string)
 	Terminate()
 	GetReceiverAddresses() []string


### PR DESCRIPTION
Agent now differentiates between c2 server address and the address of the upstream destination that it uses as a "next hop" to the C2 (could be the C2 itself, an agent peer, even a local SSH tunnel endpoint).

Contact implementations will keep track the agent's current upstream destination address as an internal variable, which it updates using the new contact interface method SetUpstreamDestAddr.

Proxy implementations will now keep track of the agent's current C2 server address and upstream contact implementation by internally storing pointers to them. Thus, there is no longer a need for explicit methods to update the upstream contact or server value for proxy implementations, since the pointers will take care of that.

Agent will modify upstream dest address if needed when checking if C2 requirements are met for the contact implementation.