### PR TITLE
Agent now sends upstream dest information to the server

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -168,6 +168,7 @@ func (a *Agent) GetFullProfile() map[string]interface{} {
 		"deadman_enabled": true,
 		"available_contacts": contact.GetAvailableCommChannels(),
 		"host_ip_addrs": a.hostIPAddrs,
+		"upstream_dest": a.upstreamDestAddr,
 	}
 }
 
@@ -179,6 +180,7 @@ func (a *Agent) GetTrimmedProfile() map[string]interface{} {
 		"platform": a.platform,
 		"host": a.host,
 		"contact": a.GetCurrentContactName(),
+		"upstream_dest": a.upstreamDestAddr,
 	}
 }
 


### PR DESCRIPTION
Requires https://github.com/mitre/caldera/pull/2081

Will send the upstream destination address in the agent profile for the server to process.