### PR TITLE
Tunnel framework

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -49,6 +49,7 @@ type AgentInterface interface {
 type Agent struct {
 	// Profile fields
 	server string
+	tunnelConfig *contact.TunnelConfig
 	group string
 	host string
 	username string
@@ -69,6 +70,8 @@ type Agent struct {
 	beaconContact contact.Contact
 	failedBeaconCounter int
 	upstreamDestAddr string // address of server/peer that agent uses to contact C2
+	tunnel contact.Tunnel
+	usingTunnel bool
 
 	// peer-to-peer info
 	enableLocalP2pReceivers bool
@@ -84,7 +87,7 @@ type Agent struct {
 }
 
 // Set up agent variables.
-func (a *Agent) Initialize(server string, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string, originLinkID int) error {
+func (a *Agent) Initialize(server string, tunnelConfig *contact.TunnelConfig, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string, originLinkID int) error {
 	host, err := os.Hostname()
 	if err != nil {
 		return err
@@ -96,6 +99,8 @@ func (a *Agent) Initialize(server string, group string, c2Config map[string]stri
 	}
 	a.server = server
 	a.upstreamDestAddr = server
+	a.tunnelConfig = tunnelConfig
+	a.tunnel = nil
 	a.group = group
 	a.host = host
 	a.architecture = runtime.GOARCH
@@ -129,6 +134,14 @@ func (a *Agent) Initialize(server string, group string, c2Config map[string]stri
 		return err
 	}
 	a.DiscoverPeers()
+
+	if len(tunnelConfig.Protocol) > 0 {
+		if err = a.StartTunnel(tunnelConfig); err != nil {
+			return err
+		}
+	} else {
+		output.VerbosePrint("[*] No tunnel protocol specified. Skipping tunnel setup.")
+	}
 
 	// Set up contacts
 	if err = a.SetCommunicationChannels(c2Config); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -237,6 +237,7 @@ func (a *Agent) HandleBeaconFailure() error {
 		// Reset counter and try switching proxy methods
 		a.failedBeaconCounter = 0
 		output.VerbosePrint("[!] Reached beacon failure threshold. Attempting to switch to new peer proxy method.")
+		a.usingTunnel = false
 		return a.findAvailablePeerProxyClient()
 	}
 	return nil
@@ -380,6 +381,9 @@ func (a *Agent) Display() {
 	if a.enableLocalP2pReceivers {
 		a.displayLocalReceiverInformation()
 	}
+	if a.usingTunnel {
+		output.VerbosePrint(fmt.Sprintf("Local tunnel endpoint=%s", a.upstreamDestAddr))
+	}
 }
 
 func (a *Agent) displayLocalReceiverInformation() {
@@ -499,7 +503,9 @@ func (a *Agent) modifyAgentConfiguration(config map[string]string) {
 
 func (a *Agent) updateUpstreamDestAddr(newDestAddr string) {
 	a.upstreamDestAddr = newDestAddr
-	a.beaconContact.SetUpstreamDestAddr(newDestAddr)
+	if a.beaconContact != nil {
+		a.beaconContact.SetUpstreamDestAddr(newDestAddr)
+	}
 }
 
 func (a *Agent) updateUpstreamComs(newComs contact.Contact) {

--- a/agent/agent_factory.go
+++ b/agent/agent_factory.go
@@ -1,10 +1,14 @@
 package agent
 
+import (
+	"github.com/mitre/gocat/contact"
+)
+
 // Creates and initializes a new Agent. Upon success, returns a pointer to the agent and nil Error.
 // Upon failure, returns nil and an error.
-func AgentFactory(server string, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string, originLinkID int) (*Agent, error) {
+func AgentFactory(server string, tunnelConfig *contact.TunnelConfig, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string, originLinkID int) (*Agent, error) {
 	newAgent := &Agent{}
-	if err := newAgent.Initialize(server, group, c2Config, enableLocalP2pReceivers, initialDelay, paw, originLinkID); err != nil {
+	if err := newAgent.Initialize(server, tunnelConfig, group, c2Config, enableLocalP2pReceivers, initialDelay, paw, originLinkID); err != nil {
 		return nil, err
 	} else {
 		newAgent.Sleep(newAgent.initialDelay)

--- a/agent/agent_tunnel.go
+++ b/agent/agent_tunnel.go
@@ -1,0 +1,34 @@
+package agent
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/mitre/gocat/contact"
+	"github.com/mitre/gocat/output"
+)
+
+func (a *Agent) StartTunnel(tunnelConfig *contact.TunnelConfig) error {
+	a.usingTunnel = false
+	tunnel, ok := contact.CommunicationTunnels[tunnelConfig.Protocol]
+	if !ok {
+		return errors.New(fmt.Sprintf("Could not find communication tunnel for protocol %s", tunnelConfig.Protocol))
+	}
+	a.tunnel = tunnel
+	if err := a.tunnel.Initialize(tunnelConfig); err != nil {
+		return err
+	}
+	output.VerbosePrint(fmt.Sprintf("[*] Starting %s tunnel", tunnel.GetName()))
+	tunnelReady := make(chan bool)
+	go a.tunnel.Run(tunnelReady)
+
+	// Wait for tunnel to be ready
+	ready := <-tunnelReady
+	if ready {
+		output.VerbosePrint(fmt.Sprintf("[*] %s tunnel ready and listening on %s.", a.tunnel.GetName(), a.tunnel.GetLocalAddr()))
+		a.updateUpstreamDestAddr(a.tunnel.GetLocalAddr())
+		a.usingTunnel = true
+		return nil
+	}
+	return errors.New(fmt.Sprintf("Failed to start communication tunnel %s", a.tunnel.GetName()))
+}

--- a/contact/tunnel.go
+++ b/contact/tunnel.go
@@ -1,0 +1,39 @@
+package contact
+
+// Tunnel defines required functions for providing a comms tunnel between agent and C2.
+type Tunnel interface {
+	GetName() string
+	Initialize(config *TunnelConfig) error
+	Run(tunnelReady chan bool) // must be run as a go routine
+	GetLocalAddr() string // agent-side address for tunnel
+	GetRemoteAddr() string // tunnel destination address
+}
+
+type TunnelConfig struct {
+	Protocol string // Name of Tunnel protocol
+	TunnelAddr string // Address used to connect to or start tunnel
+	Username string // Username to authenticate to tunnel
+	Password string // Password to authenticate to tunnel
+	TunnelDest string // Address that tunnel will ultimately connect to
+}
+
+// CommunicationTunnels contains available Tunnel implementations
+var CommunicationTunnels = map[string]Tunnel{}
+
+func GetAvailableCommTunnels() []string {
+	tunnelNames := make([]string, 0, len(CommunicationTunnels))
+	for name := range CommunicationTunnels {
+		tunnelNames = append(tunnelNames, name)
+	}
+	return tunnelNames
+}
+
+func BuildTunnelConfig(protocol, tunnelAddr, destAddr, user, password string) *TunnelConfig {
+	return &TunnelConfig{
+		Protocol: protocol,
+		TunnelAddr: destAddr,
+		Username: user,
+		Password: password,
+		TunnelDest: destAddr,
+	}
+}

--- a/contact/tunnel.go
+++ b/contact/tunnel.go
@@ -1,39 +1,138 @@
 package contact
 
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // Tunnel defines required functions for providing a comms tunnel between agent and C2.
 type Tunnel interface {
 	GetName() string
-	Initialize(config *TunnelConfig) error
-	Run(tunnelReady chan bool) // must be run as a go routine
-	GetLocalAddr() string // agent-side address for tunnel
-	GetRemoteAddr() string // tunnel destination address
+	Start(tunnelReady chan bool) // must be run as a go routine
+	GetLocalEndpoint() string // agent-side endpoint for tunnel
+	GetRemoteEndpoint() string // tunnel destination endpoint
 }
 
 type TunnelConfig struct {
 	Protocol string // Name of Tunnel protocol
-	TunnelAddr string // Address used to connect to or start tunnel
+	TunnelEndpoint string // Address used to connect to or start tunnel
 	Username string // Username to authenticate to tunnel
 	Password string // Password to authenticate to tunnel
-	TunnelDest string // Address that tunnel will ultimately connect to
+	RemoteAddr string // IP address or hostname that tunnel will ultimately connect to
+	RemotePort int // Port that tunnel will ultimately connect to
+	TunneledProtocol string // protocol that the tunnel will carry
 }
 
-// CommunicationTunnels contains available Tunnel implementations
-var CommunicationTunnels = map[string]Tunnel{}
+// CommunicationTunnels contains maps available Tunnel names to their respective factory methods.
+var CommunicationTunnelFactories = map[string]func(tunnelConfig *TunnelConfig) (Tunnel, error){}
+var defaultProtocolPorts = map[string]string{
+	"http": "80",
+	"https": "443",
+}
 
 func GetAvailableCommTunnels() []string {
-	tunnelNames := make([]string, 0, len(CommunicationTunnels))
-	for name := range CommunicationTunnels {
+	tunnelNames := make([]string, 0, len(CommunicationTunnelFactories))
+	for name := range CommunicationTunnelFactories {
 		tunnelNames = append(tunnelNames, name)
 	}
 	return tunnelNames
 }
 
-func BuildTunnelConfig(protocol, tunnelAddr, destAddr, user, password string) *TunnelConfig {
+func BuildTunnelConfig(protocol, tunnelEndpoint, destEndpoint, user, password string) (*TunnelConfig, error) {
+	tunneledProtocol, remoteEndpoint := getTunneledProtocolAndRemoteAddr(destEndpoint)
+	remoteAddr, remotePort, err := splitAddrAndPort(remoteEndpoint, tunneledProtocol)
+	if err != nil {
+		return nil, err
+	}
 	return &TunnelConfig{
 		Protocol: protocol,
-		TunnelAddr: destAddr,
+		TunnelEndpoint: tunnelEndpoint,
 		Username: user,
 		Password: password,
-		TunnelDest: destAddr,
+		RemoteAddr: remoteAddr,
+		RemotePort: remotePort,
+		TunneledProtocol: tunneledProtocol,
+	}, nil
+}
+
+// Determine which protocol will be tunneled as well as the remote endpoint,
+// based on the address provided by tunnelConfig.TunnelDest. If the protocol is not specified,
+// "http" will be returned along with the remote endpoint addr.
+//
+// Examples:
+//	https://10.10.10.10:8888 -> https, 10.10.10.10:8888
+//	10.10.10.10.:8888 -> http, 10.10.10.10:8888
+func getTunneledProtocolAndRemoteAddr(remoteAddr string) (string, string) {
+	protocolSplit := strings.Split(remoteAddr, "://")
+	if len(protocolSplit) == 1 {
+		// No protocol was specified.
+		return "http", protocolSplit[0]
+	} else {
+		return protocolSplit[0], protocolSplit[1]
 	}
+}
+
+// Split string of the form address:port or hostname:port into the IP address and port pair. Only supports IPv4.
+// If no port is explicitly provided, the default according the provided protocol will be returned.
+func splitAddrAndPort(addrAndPort string, protocol string) (string, int, error) {
+	addrPortSplit := strings.Split(addrAndPort, ":")
+	addr := addrPortSplit[0]
+	var portStr string
+	if len(addrPortSplit) == 1 {
+		// No port specified. Use default port according to protocol.
+		if defaultPort, ok := defaultProtocolPorts[protocol]; ok {
+			portStr = defaultPort
+		} else {
+			return "", -1, errors.New(fmt.Sprintf("Could not get default port for protocol %s", protocol))
+		}
+	} else {
+		portStr = addrPortSplit[1]
+	}
+	if len(addr) == 0 {
+		return "", -1, errors.New("Empty address/hostname provided.")
+	}
+	if len(portStr) == 0 {
+		return "", -1, errors.New("Empty port provided.")
+	}
+	if portNum, err := strconv.Atoi(portStr); err == nil {
+		return addr, portNum, nil
+	}
+	return "", -1, errors.New(fmt.Sprintf("Invalid endpoint provided: %s", addrAndPort))
+}
+
+// Parse endpoint addr string (e.g. http://192.168.10.1:8888) into the protocol, IP/hostname, and port string.
+// Returns error if addr string is not of expected format. Only supports IPv4.
+func getEndpointInfo(endpointAddr string) (string, string, string, error) {
+	protocolSplit := strings.Split(endpointAddr, "://")
+	var addrAndPort string
+	protocol := ""
+	if len(protocolSplit) == 1 {
+		// No protocol was specified.
+		addrAndPort = protocolSplit[0]
+	} else {
+		addrAndPort = protocolSplit[1]
+		protocol = protocolSplit[0]
+	}
+	addrPortSplit := strings.Split(addrAndPort, ":")
+	addr := addrPortSplit[0]
+	var port string
+	if len(addrPortSplit) == 1 {
+		// No port specified. Use default port according to protocol.
+		if defaultPort, ok := defaultProtocolPorts[protocol]; ok {
+			port = defaultPort
+		} else {
+			return "", "", "", errors.New(fmt.Sprintf("Could not get default port for protocol %s", protocol))
+		}
+	} else {
+		port = addrPortSplit[1]
+	}
+	if len(addr) == 0 {
+		return "", "", "", errors.New("Empty address/hostname provided.")
+	}
+	if len(port) == 0 {
+		return "", "", "", errors.New("Empty port provided.")
+	}
+	return protocol, addr, port, nil
 }

--- a/core/core.go
+++ b/core/core.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/mitre/gocat/agent"
+	"github.com/mitre/gocat/contact"
 	"github.com/mitre/gocat/output"
 
 	_ "github.com/mitre/gocat/execute/donut"     // necessary to initialize all submodules
@@ -16,21 +17,21 @@ import (
 )
 
 // Initializes and returns sandcat agent.
-func initializeCore(server string, group string, c2 map[string]string, p2pReceiversOn bool, initialDelay int, verbose bool, paw string, originLinkID int) (*agent.Agent, error) {
+func initializeCore(server string, tunnelConfig *contact.TunnelConfig, group string, contactConfig map[string]string, p2pReceiversOn bool, initialDelay int, verbose bool, paw string, originLinkID int) (*agent.Agent, error) {
 	output.SetVerbose(verbose)
 	output.VerbosePrint("Starting sandcat in verbose mode.")
-	return agent.AgentFactory(server, group, c2, p2pReceiversOn, initialDelay, paw, originLinkID)
+	return agent.AgentFactory(server, tunnelConfig, group, contactConfig, p2pReceiversOn, initialDelay, paw, originLinkID)
 }
 
 //Core is the main function as wrapped by sandcat.go
-func Core(server string, group string, delay int, c2 map[string]string, p2pReceiversOn bool, verbose bool, paw string, originLinkID int) {
-	sandcatAgent, err := initializeCore(server, group, c2, p2pReceiversOn, delay, verbose, paw, originLinkID)
+func Core(server string, tunnelConfig *contact.TunnelConfig, group string, delay int, contactConfig map[string]string, p2pReceiversOn bool, verbose bool, paw string, originLinkID int) {
+	sandcatAgent, err := initializeCore(server, tunnelConfig, group, contactConfig, p2pReceiversOn, delay, verbose, paw, originLinkID)
 	if err != nil {
 		output.VerbosePrint(fmt.Sprintf("[-] Error when initializing agent: %s", err.Error()))
 		output.VerbosePrint("[-] Exiting.")
 	} else {
 		sandcatAgent.Display()
-		runAgent(sandcatAgent, c2)
+		runAgent(sandcatAgent, contactConfig)
 		sandcatAgent.Terminate()
 	}
 }

--- a/sandcat.go
+++ b/sandcat.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -46,7 +47,15 @@ func main() {
 	flag.Parse()
 
 	trimmedServer := strings.TrimRight(*server, "/")
-	tunnelConfig := contact.BuildTunnelConfig(*tunnelProtocol, *tunnelAddr, trimmedServer, *tunnelUsername, *tunnelPassword)
-	contactConfig := map[string]string{"c2Name": *c2Protocol, "c2Key": c2Key, "httpProxyGateway": *httpProxyUrl}
+	tunnelConfig, err := contact.BuildTunnelConfig(*tunnelProtocol, *tunnelAddr, trimmedServer, *tunnelUsername, *tunnelPassword)
+	if err != nil && *verbose {
+		fmt.Println(fmt.Sprintf("[!] Error building tunnel config: %s", err.Error()))
+		return
+	}
+	contactConfig := map[string]string{
+		"c2Name": *c2Protocol,
+		"c2Key": c2Key,
+		"httpProxyGateway": *httpProxyUrl,
+	}
 	core.Core(trimmedServer, tunnelConfig, *group, *delay, contactConfig, *listenP2P, *verbose, *paw, *originLinkID)
 }

--- a/sandcat.go
+++ b/sandcat.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/mitre/gocat/contact"
 	"github.com/mitre/gocat/core"
 )
 
@@ -32,15 +33,20 @@ func main() {
 	httpProxyUrl :=  flag.String("httpProxyGateway", httpProxyGateway, "URL for the HTTP proxy gateway. For environments that use proxies to reach the internet.")
 	paw := flag.String("paw", paw, "Optionally specify a PAW on intialization")
 	group := flag.String("group", group, "Attach a group to this agent")
-	c2 := flag.String("c2", c2Name, "C2 Channel for agent")
+	c2Protocol := flag.String("c2", c2Name, "C2 Channel for agent")
 	delay := flag.Int("delay", 0, "Delay starting this agent by n-seconds")
 	verbose := flag.Bool("v", false, "Enable verbose output")
 	listenP2P := flag.Bool("listenP2P", parsedListenP2P, "Enable peer-to-peer receivers")
 	originLinkID := flag.Int("originLinkID", 0, "Optionally set originating link ID")
+	tunnelProtocol := flag.String("tunnelProtocol", "", "C2 comms tunnel type to use.")
+	tunnelAddr := flag.String("tunnelAddr", "", "Address used to connect to or start the tunnel.")
+	tunnelUsername := flag.String("tunnelUser", "", "Username used to authenticate to the tunnel.")
+	tunnelPassword := flag.String("tunnelPassword", "", "Password used to authenticate to the tunnel.")
 
 	flag.Parse()
 
-    trimmedServer := strings.TrimRight(*server, "/")
-	c2Config := map[string]string{"c2Name": *c2, "c2Key": c2Key, "httpProxyGateway": *httpProxyUrl}
-	core.Core(trimmedServer, *group, *delay, c2Config, *listenP2P, *verbose, *paw, *originLinkID)
+	trimmedServer := strings.TrimRight(*server, "/")
+	tunnelConfig := contact.BuildTunnelConfig(*tunnelProtocol, *tunnelAddr, trimmedServer, *tunnelUsername, *tunnelPassword)
+	contactConfig := map[string]string{"c2Name": *c2Protocol, "c2Key": c2Key, "httpProxyGateway": *httpProxyUrl}
+	core.Core(trimmedServer, tunnelConfig, *group, *delay, contactConfig, *listenP2P, *verbose, *paw, *originLinkID)
 }


### PR DESCRIPTION
Adding framework to add communication tunnel mechanisms to the sandcat agent, in a modular fashion similar to contacts. A new `Tunnel` interface is defined in the `contact` package, which defines required methods for a communication tunnel. A `TunnelConfig` struct is also defined, which contains parameters for initializing a communication tunnel. The `contact` package now contains a `CommunicationTunnelFactories` map that maps tunneling protocol names to their respective factory methods that return a `Tunnel` implementation. 

To add tunnel implementations, simply add new `.go` files into the `contact` package that implement the factory method and tunnel object. The factory method will need to be added to the `CommunicationTunnelFactories` mapping under the appropriate tunnel protocol name (e.g. `CommunicationTunnelFactories["SSH"] = SshTunnelFactory`)

When starting an agent, users can now use 4 new command-line arguments to set up a tunneling mechanism:
- `tunnelProtocol` - name of tunnel protocol to use (e.g. `SSH`). Must match the protocol name used as the key in `CommunicationTunnelFactories`
- `tunnelAddr` - Address used to connect to or start the tunnel. For example, with an SSH tunnel this would be the IP/port endpoint for the SSH server (e.g. `127.0.0.1:8022`)
- `tunnelUser` - username to authenticate for the tunnel, if required
- `tunnelPassword` - password to authenticate for the tunnel, if required