### PR TITLE
Adding encoder interface and base64 and plaintext encoders

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/mitre/gocat/contact"
+	"github.com/mitre/gocat/encoders"
 	"github.com/mitre/gocat/execute"
 	"github.com/mitre/gocat/output"
 	"github.com/mitre/gocat/privdetect"
@@ -65,6 +66,7 @@ type Agent struct {
 	initialDelay float64
 	originLinkID int
 	hostIPAddrs []string
+	availableDataEncoders []string
 
 	// Communication methods
 	beaconContact contact.Contact
@@ -114,6 +116,7 @@ func (a *Agent) Initialize(server string, tunnelConfig *contact.TunnelConfig, gr
 	a.initialDelay = float64(initialDelay)
 	a.failedBeaconCounter = 0
 	a.originLinkID = originLinkID
+	a.availableDataEncoders = encoders.GetAvailableDataEncoders()
 
 	a.hostIPAddrs, err = proxy.GetLocalIPv4Addresses()
 	if err != nil {
@@ -384,6 +387,7 @@ func (a *Agent) Display() {
 	if a.usingTunnel {
 		output.VerbosePrint(fmt.Sprintf("Local tunnel endpoint=%s", a.upstreamDestAddr))
 	}
+	output.VerbosePrint(fmt.Sprintf("available data encoders=%s", strings.Join(a.availableDataEncoders, ", ")))
 }
 
 func (a *Agent) displayLocalReceiverInformation() {

--- a/encoders/base64.go
+++ b/encoders/base64.go
@@ -1,0 +1,28 @@
+package encoders
+
+import (
+	"encoding/base64"
+)
+
+//Base64Encoder encodes and decodes data using base64
+type Base64Encoder struct {
+	name string
+}
+
+func init() {
+	DataEncoders["base64"] = &Base64Encoder{ name: "base64" }
+}
+
+func (b *Base64Encoder) GetName() string {
+	return b.name
+}
+
+func (b *Base64Encoder) EncodeData(data []byte, config map[string]interface{}) ([]byte, error) {
+	encodedStr := base64.StdEncoding.EncodeToString(data)
+	return []byte(encodedStr), nil
+}
+
+func (b *Base64Encoder) DecodeData(data []byte, config map[string]interface{}) ([]byte, error) {
+	encodedStr := string(data)
+	return base64.StdEncoding.DecodeString(encodedStr)
+}

--- a/encoders/encoder.go
+++ b/encoders/encoder.go
@@ -1,0 +1,20 @@
+package encoders
+
+// DataEncoder defines required functions for encoding/decoding data/files.
+type DataEncoder interface {
+	GetName() string
+	EncodeData(data []byte, config map[string]interface{}) ([]byte, error)
+	DecodeData(data []byte, config map[string]interface{}) ([]byte, error)
+}
+
+//DataEncoders contains the data encoder implementations
+var DataEncoders = map[string]DataEncoder{}
+
+// Get available data encoder implementations
+func GetAvailableDataEncoders() []string {
+	encoderNames := make([]string, 0, len(DataEncoders))
+	for encoderName := range DataEncoders {
+		encoderNames = append(encoderNames, encoderName)
+	}
+	return encoderNames
+}

--- a/encoders/plaintext.go
+++ b/encoders/plaintext.go
@@ -1,0 +1,22 @@
+package encoders
+
+//Base64Encoder encodes and decodes data using base64
+type PlaintextEncoder struct {
+	name string
+}
+
+func init() {
+	DataEncoders["plain-text"] = &PlaintextEncoder{ name: "plain-text" }
+}
+
+func (p *PlaintextEncoder) GetName() string {
+	return p.name
+}
+
+func (p *PlaintextEncoder) EncodeData(data []byte, config map[string]interface{}) ([]byte, error) {
+	return data, nil
+}
+
+func (p *PlaintextEncoder) DecodeData(data []byte, config map[string]interface{}) ([]byte, error) {
+	return data, nil
+}


### PR DESCRIPTION
Adding data encoder interface and base64/plaintext implementations. Also adding new agent field "availableDataEncoders", which is a string slice of available data encoder names. The agent will display these encoder names when starting up.

Future PRs will use these encoders for payloads/uploads.