### PR TITLE
[VIRTS-2255] Agents report command execution time

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -271,7 +271,7 @@ func (a *Agent) RunInstruction(instruction map[string]interface{}, submitResults
 	}
 
 	// Execute command
-	commandOutput, status, pid := execute.RunCommand(info)
+	commandOutput, status, pid, commandTimestamp := execute.RunCommand(info)
 
 	// Clean up payloads
 	a.removePayloadsOnDisk(onDiskPayloads)
@@ -282,6 +282,7 @@ func (a *Agent) RunInstruction(instruction map[string]interface{}, submitResults
 		result["output"] = commandOutput
 		result["status"] = status
 		result["pid"] = pid
+		result["agent_reported_time"] = getFormattedTimestamp(commandTimestamp, "2006-01-02 03:04:05")
 		output.VerbosePrint(fmt.Sprintf("[*] Submitting results for link %s via C2 channel %s", result["id"].(string), a.GetCurrentContactName()))
 		a.beaconContact.SendExecutionResults(a.GetTrimmedProfile(), result)
 	}

--- a/agent/agent_util.go
+++ b/agent/agent_util.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/user"
 	"os/exec"
+	"time"
 )
 
 // Checks for a file
@@ -45,4 +46,8 @@ func getUsername() (string, error) {
 	} else {
 		return userInfo.Username, nil
 	}
+}
+
+func getFormattedTimestamp(timestamp time.Time, dateFormat string) (string) {
+    return timestamp.Format(dateFormat)
 }

--- a/execute/shells/cmd.go
+++ b/execute/shells/cmd.go
@@ -5,6 +5,7 @@ package shells
 import (
 	"github.com/mitre/gocat/execute"
 	"os/exec"
+	"time"
 )
 
 type Cmd struct {
@@ -24,7 +25,7 @@ func init() {
 	}
 }
 
-func (c *Cmd) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+func (c *Cmd) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
 	return runShellExecutor(*exec.Command(c.path, append(c.execArgs, command)...), timeout)
 }
 

--- a/execute/shells/powershell.go
+++ b/execute/shells/powershell.go
@@ -5,6 +5,7 @@ package shells
 import (
 	"github.com/mitre/gocat/execute"
 	"os/exec"
+	"time"
 )
 
 type Powershell struct {
@@ -24,7 +25,7 @@ func init() {
 	}
 }
 
-func (p *Powershell) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+func (p *Powershell) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
 	return runShellExecutor(*exec.Command(p.path, append(p.execArgs, command)...), timeout)
 }
 

--- a/execute/shells/shell.go
+++ b/execute/shells/shell.go
@@ -3,6 +3,7 @@ package shells
 import (
 	"github.com/mitre/gocat/execute"
 	"os/exec"
+	"time"
 )
 
 type Sh struct {
@@ -20,7 +21,7 @@ func init() {
 	}
 }
 
-func (s *Sh) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+func (s *Sh) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
 	return runShellExecutor(*exec.Command(s.path, append(s.execArgs, command)...), timeout)
 }
 

--- a/sandcat.go
+++ b/sandcat.go
@@ -32,7 +32,7 @@ func main() {
 	}
 	server := flag.String("server", server, "The FQDN of the server")
 	httpProxyUrl :=  flag.String("httpProxyGateway", httpProxyGateway, "URL for the HTTP proxy gateway. For environments that use proxies to reach the internet.")
-	paw := flag.String("paw", paw, "Optionally specify a PAW on intialization")
+	paw := flag.String("paw", paw, "Optionally specify a PAW on initialization")
 	group := flag.String("group", group, "Attach a group to this agent")
 	c2Protocol := flag.String("c2", c2Name, "C2 Channel for agent")
 	delay := flag.Int("delay", 0, "Delay starting this agent by n-seconds")


### PR DESCRIPTION
## Description

Implements the agent change for mitre/caldera#2163

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Manually deploy this agent to a machine and perform an operation. The event logs and full report should reflect a new field `agent_reported_time`.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works