### PR TITLE
Adding process executor

### DIFF
--- a/execute/shells/proc.go
+++ b/execute/shells/proc.go
@@ -49,7 +49,6 @@ func (p *Proc) DownloadPayloadToMemory(payloadName string) bool {
 }
 
 func (p *Proc) getExeAndArgs(commandLine string) (string, []string, error) {
-	output.VerbosePrint(fmt.Sprintf("[*] Processing commandline %s", commandLine))
 	if runtime.GOOS == "windows" {
 		commandLine = strings.ReplaceAll(commandLine, "\\", "\\\\")
 	}
@@ -57,9 +56,5 @@ func (p *Proc) getExeAndArgs(commandLine string) (string, []string, error) {
 	if err != nil {
 		return "", nil, err
 	}
-	execPath := split[0]
-	if strings.HasPrefix(execPath, ".") {
-		execPath = strings.Replace(execPath, ".", p.currDir, 1)
-	}
-	return execPath, split[1:], nil
+	return split[0], split[1:], nil
 }

--- a/execute/shells/proc.go
+++ b/execute/shells/proc.go
@@ -1,0 +1,65 @@
+package shells
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"github.com/google/shlex"
+
+	"github.com/mitre/gocat/execute"
+	"github.com/mitre/gocat/output"
+)
+
+type Proc struct {
+	name string
+	currDir string
+}
+
+func init() {
+	cwd, _ := os.Getwd()
+    executor := &Proc{
+		name: "proc",
+		currDir: cwd,
+	}
+	execute.Executors[executor.name] = executor
+}
+
+func (p *Proc) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string) {
+	exePath, exeArgs, err := p.getExeAndArgs(command)
+	if err != nil {
+		output.VerbosePrint(fmt.Sprintf("[!] Error parsing command line: %s", err.Error()))
+		return nil, "", ""
+	}
+	output.VerbosePrint(fmt.Sprintf("[*] Starting process %s with args %v", exePath, exeArgs))
+	return runShellExecutor(*exec.Command(exePath, append(exeArgs)...), timeout)
+}
+
+func (p *Proc) String() string {
+	return p.name
+}
+
+func (p *Proc) CheckIfAvailable() bool {
+	return true
+}
+
+func (p *Proc) DownloadPayloadToMemory(payloadName string) bool {
+	return false
+}
+
+func (p *Proc) getExeAndArgs(commandLine string) (string, []string, error) {
+	output.VerbosePrint(fmt.Sprintf("[*] Processing commandline %s", commandLine))
+	if runtime.GOOS == "windows" {
+		commandLine = strings.ReplaceAll(commandLine, "\\", "\\\\")
+	}
+	split, err := shlex.Split(commandLine)
+	if err != nil {
+		return "", nil, err
+	}
+	execPath := split[0]
+	if strings.HasPrefix(execPath, ".") {
+		execPath = strings.Replace(execPath, ".", p.currDir, 1)
+	}
+	return execPath, split[1:], nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mitre/gocat
 go 1.13
 
 require (
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/grandcat/zeroconf v1.0.0
 	golang.org/x/crypto v0.0.0-20210415154028-4f45737414dc
 )


### PR DESCRIPTION
Adding new process executor to sandcat agent: "proc". This executor takes a command line string consisting of an executable name and arguments (if any) and runs the command without spawning a new cmd, sh, or powershell process. This is useful in environments where some of the traditional executors, like cmd or powershell, are restricted or blocked.

To add this executor to an ability, use the "proc" executor name like below:
```
platforms:
    windows:
      proc:
        command: |
          MyExecutable.exe arg1 arg2 "arg with spaces" arg4
        payloads:
          - MyExecutable.exe
```
The executable path can be absolute (or reference current directory), or without any directory prefix to use the normal path environment variable searching (e.g. just "whoami.exe" will normally automatically invoke C:\Windows\System32\whoami.exe)

Note that the spawned process is not detached, meaning the agent will attempt to wait until timeout is reached. Thus, we recommend avoiding executables that run forever (e.g. spawning "notepad.exe")