### PR TITLE
cmd executor properly handles quoted executable paths

### DIFF
--- a/execute/shells/cmd.go
+++ b/execute/shells/cmd.go
@@ -5,6 +5,8 @@ package shells
 import (
 	"github.com/mitre/gocat/execute"
 	"os/exec"
+	"strings"
+	"syscall"
 	"time"
 )
 
@@ -26,7 +28,11 @@ func init() {
 }
 
 func (c *Cmd) Run(command string, timeout int, info execute.InstructionInfo) ([]byte, string, string, time.Time) {
-	return runShellExecutor(*exec.Command(c.path, append(c.execArgs, command)...), timeout)
+	cmd := *exec.Command(c.path)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	commandLineComponents := append(append([]string{c.path}, c.execArgs...), command)
+	cmd.SysProcAttr.CmdLine = strings.Join(commandLineComponents, " ")
+	return runShellExecutor(cmd, timeout)
 }
 
 func (c *Cmd) String() string {

--- a/execute/shells/shells_shared.go
+++ b/execute/shells/shells_shared.go
@@ -21,7 +21,9 @@ func runShellExecutor(cmd exec.Cmd, timeout int) ([]byte, string, string, time.T
 	done := make(chan error, 1)
 	status := execute.SUCCESS_STATUS
 	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.SysProcAttr = getPlatformSysProcAttrs()
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = getPlatformSysProcAttrs()
+	}
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
 	executionTimestamp := time.Now()


### PR DESCRIPTION
Patch for https://github.com/mitre/caldera/issues/2160

Will pass in the full command line to SysProcAttr.CmdLine so that cmd.exe can use its own quote handling mechanism, as per https://golang.org/pkg/os/exec/#Command.