### PR TITLE
Handle origin link ID as string

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -64,7 +64,7 @@ type Agent struct {
 	exe_name string
 	paw string
 	initialDelay float64
-	originLinkID int
+	originLinkID string
 	hostIPAddrs []string
 	availableDataEncoders []string
 
@@ -89,7 +89,7 @@ type Agent struct {
 }
 
 // Set up agent variables.
-func (a *Agent) Initialize(server string, tunnelConfig *contact.TunnelConfig, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string, originLinkID int) error {
+func (a *Agent) Initialize(server string, tunnelConfig *contact.TunnelConfig, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string, originLinkID string) error {
 	host, err := os.Hostname()
 	if err != nil {
 		return err

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -78,7 +78,7 @@ type Agent struct {
 	// peer-to-peer info
 	enableLocalP2pReceivers   bool
 	p2pReceiverWaitGroup      *sync.WaitGroup
-	localP2pReceivers        map[string]proxy.P2pReceiver // maps P2P protocol to receiver running on this machine
+	localP2pReceivers         map[string]proxy.P2pReceiver // maps P2P protocol to receiver running on this machine
 	localP2pReceiverAddresses map[string][]string          // maps P2P protocol to receiver addresses listening on this machine
 	availablePeerReceivers    map[string][]string          // maps P2P protocol to receiver addresses running on peer machines
 	exhaustedPeerReceivers    map[string][]string          // maps P2P protocol to receiver addresses that the agent has tried using.

--- a/agent/agent_factory.go
+++ b/agent/agent_factory.go
@@ -6,7 +6,7 @@ import (
 
 // Creates and initializes a new Agent. Upon success, returns a pointer to the agent and nil Error.
 // Upon failure, returns nil and an error.
-func AgentFactory(server string, tunnelConfig *contact.TunnelConfig, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string, originLinkID int) (*Agent, error) {
+func AgentFactory(server string, tunnelConfig *contact.TunnelConfig, group string, c2Config map[string]string, enableLocalP2pReceivers bool, initialDelay int, paw string, originLinkID string) (*Agent, error) {
 	newAgent := &Agent{}
 	if err := newAgent.Initialize(server, tunnelConfig, group, c2Config, enableLocalP2pReceivers, initialDelay, paw, originLinkID); err != nil {
 		return nil, err

--- a/core/core.go
+++ b/core/core.go
@@ -17,14 +17,14 @@ import (
 )
 
 // Initializes and returns sandcat agent.
-func initializeCore(server string, tunnelConfig *contact.TunnelConfig, group string, contactConfig map[string]string, p2pReceiversOn bool, initialDelay int, verbose bool, paw string, originLinkID int) (*agent.Agent, error) {
+func initializeCore(server string, tunnelConfig *contact.TunnelConfig, group string, contactConfig map[string]string, p2pReceiversOn bool, initialDelay int, verbose bool, paw string, originLinkID string) (*agent.Agent, error) {
 	output.SetVerbose(verbose)
 	output.VerbosePrint("Starting sandcat in verbose mode.")
 	return agent.AgentFactory(server, tunnelConfig, group, contactConfig, p2pReceiversOn, initialDelay, paw, originLinkID)
 }
 
 //Core is the main function as wrapped by sandcat.go
-func Core(server string, tunnelConfig *contact.TunnelConfig, group string, delay int, contactConfig map[string]string, p2pReceiversOn bool, verbose bool, paw string, originLinkID int) {
+func Core(server string, tunnelConfig *contact.TunnelConfig, group string, delay int, contactConfig map[string]string, p2pReceiversOn bool, verbose bool, paw string, originLinkID string) {
 	sandcatAgent, err := initializeCore(server, tunnelConfig, group, contactConfig, p2pReceiversOn, delay, verbose, paw, originLinkID)
 	if err != nil {
 		output.VerbosePrint(fmt.Sprintf("[-] Error when initializing agent: %s", err.Error()))

--- a/sandcat.go
+++ b/sandcat.go
@@ -38,7 +38,7 @@ func main() {
 	delay := flag.Int("delay", 0, "Delay starting this agent by n-seconds")
 	verbose := flag.Bool("v", false, "Enable verbose output")
 	listenP2P := flag.Bool("listenP2P", parsedListenP2P, "Enable peer-to-peer receivers")
-	originLinkID := flag.Int("originLinkID", 0, "Optionally set originating link ID")
+	originLinkID := flag.String("originLinkID", "", "Optionally set originating link ID")
 	tunnelProtocol := flag.String("tunnelProtocol", "", "C2 comms tunnel type to use.")
 	tunnelAddr := flag.String("tunnelAddr", "", "Address used to connect to or start the tunnel.")
 	tunnelUsername := flag.String("tunnelUser", "", "Username used to authenticate to the tunnel.")


### PR DESCRIPTION
Updating method signatures and agent link ID storage to match UUID format for link ID

Requires https://github.com/mitre/caldera/pull/2187

Addresses origin link ID issue in https://github.com/mitre/caldera/issues/2162 