### PR TITLE
Set up executor update function

### DIFF
--- a/execute/execute.go
+++ b/execute/execute.go
@@ -23,6 +23,7 @@ type Executor interface {
 	Run(command string, timeout int, info InstructionInfo) ([]byte, string, string, time.Time)
 	String() string
 	CheckIfAvailable() bool
+	UpdateBinary(newBinary string)
 
 	// Returns true if the executor wants the payload downloaded to memory, false if it wants the payload on disk.
 	DownloadPayloadToMemory(payloadName string) bool

--- a/execute/shells/cmd.go
+++ b/execute/shells/cmd.go
@@ -46,3 +46,7 @@ func (c *Cmd) CheckIfAvailable() bool {
 func (c* Cmd) DownloadPayloadToMemory(payloadName string) bool {
 	return false
 }
+
+func (c* Cmd) UpdateBinary(newBinary string) {
+	c.path = newBinary
+}

--- a/execute/shells/powershell.go
+++ b/execute/shells/powershell.go
@@ -40,3 +40,7 @@ func (p *Powershell) CheckIfAvailable() bool {
 func (p* Powershell) DownloadPayloadToMemory(payloadName string) bool {
 	return false
 }
+
+func (p *Powershell) UpdateBinary(newBinary string) {
+	p.path = newBinary
+}

--- a/execute/shells/proc.go
+++ b/execute/shells/proc.go
@@ -59,3 +59,7 @@ func (p *Proc) getExeAndArgs(commandLine string) (string, []string, error) {
 	}
 	return split[0], split[1:], nil
 }
+
+func (p *Proc) UpdateBinary(newBinary string) {
+	return
+}

--- a/execute/shells/shell.go
+++ b/execute/shells/shell.go
@@ -36,3 +36,7 @@ func (s *Sh) CheckIfAvailable() bool {
 func (s* Sh) DownloadPayloadToMemory(payloadName string) bool {
 	return false
 }
+
+func (s* Sh) UpdateBinary(newBinary string) {
+	s.path = newBinary
+}


### PR DESCRIPTION
Extending executor interface to allow executors to update their binary paths, if applicable