### PR TITLE
Adding built-in delete functionality for proc executor

### DIFF
--- a/execute/shells/proc.go
+++ b/execute/shells/proc.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 	"github.com/google/shlex"
@@ -34,6 +35,9 @@ func (p *Proc) Run(command string, timeout int, info execute.InstructionInfo) ([
 		return nil, "", "", time.Now()
 	}
 	output.VerbosePrint(fmt.Sprintf("[*] Starting process %s with args %v", exePath, exeArgs))
+	if exePath == "del" || exePath == "rm" {
+		return p.deleteFiles(exeArgs)
+	}
 	return runShellExecutor(*exec.Command(exePath, append(exeArgs)...), timeout)
 }
 
@@ -62,4 +66,24 @@ func (p *Proc) getExeAndArgs(commandLine string) (string, []string, error) {
 
 func (p *Proc) UpdateBinary(newBinary string) {
 	return
+}
+
+func (p *Proc) deleteFiles(files []string) ([]byte, string, string, time.Time) {
+	pid := strconv.Itoa(os.Getpid())
+	var outputMessages []string
+	var msg string
+	var err error
+	status := execute.SUCCESS_STATUS
+	executionTimestamp := time.Now()
+	for _, toDelete := range files {
+		err = os.Remove(toDelete)
+		if err != nil {
+			msg = fmt.Sprintf("Failed to remove %s: %s", toDelete, err.Error())
+			status = execute.ERROR_STATUS
+		} else {
+			msg = fmt.Sprintf("Removed file %s.", toDelete)
+		}
+		outputMessages = append(outputMessages, msg)
+	}
+	return []byte(strings.Join(outputMessages, "\n")), status, pid, executionTimestamp
 }


### PR DESCRIPTION
Allowing proc executor to delete files as specified in the ability file command. Useful for cleanup commands for environments that don't allow powershell or cmd.

If the ability command starts with `del` or `rm`, then the agent will delete the following files without having to spawn a new process.

E.g. `del file1 file2 file3` will instruct the agent to delete `file1`, `file2`, `file3`. Returns successful status if all files were deleted successfully - otherwise it'll return an error status and will print out the delete errors.