### PR TITLE
Agent now maintains full executable path for linux/mac

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -107,7 +107,10 @@ func (a *Agent) Initialize(server string, tunnelConfig *contact.TunnelConfig, gr
 	a.host = host
 	a.architecture = runtime.GOARCH
 	a.platform = runtime.GOOS
-	a.location = os.Args[0]
+	a.location, err = os.Executable()
+	if err != nil {
+		return err
+	}
 	a.pid = os.Getpid()
 	a.ppid = os.Getppid()
 	a.privilege = privdetect.Privlevel()


### PR DESCRIPTION
Before, the agent profile only had the full file path for the agent executable when running on Windows - when running on LInux/Mac, if the agent was started using a relative file path, then the profile would contain that same relative file path. This fix ensure that the profile contains the absolute file path to the executable on Windows, Linux, and Mac.

Tested by running the agent executable from various directories on Windows, Linux, and Mac.