### PR TITLE
Send execution timestamps in UTC rather than local time

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -289,7 +289,7 @@ func (a *Agent) runInstructionCommand(instruction map[string]interface{}) map[st
 	result["output"] = commandOutput
 	result["status"] = status
 	result["pid"] = pid
-	result["agent_reported_time"] = getFormattedTimestamp(commandTimestamp, "2006-01-02 03:04:05")
+	result["agent_reported_time"] = getFormattedTimestamp(commandTimestamp, "2006-01-02T15:04:05Z")
 	return result
 }
 

--- a/execute/execute.go
+++ b/execute/execute.go
@@ -60,7 +60,7 @@ func RunCommand(info InstructionInfo) ([]byte, string, string, time.Time) {
 		result = []byte(fmt.Sprintf("Error when decoding command: %s", err.Error()))
 		status = ERROR_STATUS
 		pid = ERROR_STATUS
-		executionTimestamp = time.Now()
+		executionTimestamp = time.Now().UTC()
 	} else {
 		command := string(decoded)
 		missingPaths := checkPayloadsAvailable(onDiskPayloads)
@@ -70,7 +70,7 @@ func RunCommand(info InstructionInfo) ([]byte, string, string, time.Time) {
 			result = []byte(fmt.Sprintf("Payload(s) not available: %s", strings.Join(missingPaths, ", ")))
 			status = ERROR_STATUS
 			pid = ERROR_STATUS
-			executionTimestamp = time.Now()
+			executionTimestamp = time.Now().UTC()
 		}
 	}
 	return result, status, pid, executionTimestamp

--- a/execute/shells/proc.go
+++ b/execute/shells/proc.go
@@ -32,7 +32,7 @@ func (p *Proc) Run(command string, timeout int, info execute.InstructionInfo) ([
 	exePath, exeArgs, err := p.getExeAndArgs(command)
 	if err != nil {
 		output.VerbosePrint(fmt.Sprintf("[!] Error parsing command line: %s", err.Error()))
-		return nil, "", "", time.Now()
+		return nil, "", "", time.Now().UTC()
 	}
 	output.VerbosePrint(fmt.Sprintf("[*] Starting process %s with args %v", exePath, exeArgs))
 	if exePath == "del" || exePath == "rm" {
@@ -74,7 +74,7 @@ func (p *Proc) deleteFiles(files []string) ([]byte, string, string, time.Time) {
 	var msg string
 	var err error
 	status := execute.SUCCESS_STATUS
-	executionTimestamp := time.Now()
+	executionTimestamp := time.Now().UTC()
 	for _, toDelete := range files {
 		err = os.Remove(toDelete)
 		if err != nil {

--- a/execute/shells/shells_shared.go
+++ b/execute/shells/shells_shared.go
@@ -26,7 +26,7 @@ func runShellExecutor(cmd exec.Cmd, timeout int) ([]byte, string, string, time.T
 	}
 	cmd.Stdout = &stdoutBuf
 	cmd.Stderr = &stderrBuf
-	executionTimestamp := time.Now()
+	executionTimestamp := time.Now().UTC()
 	err := cmd.Start()
 	if err != nil {
 		return []byte(fmt.Sprintf("Encountered an error starting the process: %q", err.Error())), execute.ERROR_STATUS, execute.ERROR_PID, executionTimestamp


### PR DESCRIPTION
Agents will now report link completion time in UTC format, following the YYYY-MM-DDTHH:MM:SSZ format.

Compatible with the main branch PR: [mitre/caldera#2355](https://github.com/mitre/caldera/pull/2355)